### PR TITLE
Add host cache

### DIFF
--- a/pkg/dynatrace-client/client.go
+++ b/pkg/dynatrace-client/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 )
@@ -27,7 +26,7 @@ type Client interface {
 	// Returns the version string formatted as "Major.Minor.Revision.Timestamp" on success.
 	//
 	// Returns an error for the following conditions:
-	//  - the IP is invalid (nil or empty)
+	//  - the IP is empty
 	//  - IO error or unexpected response
 	//  - error response from the server (e.g. authentication failure)
 	//  - a host with the given IP cannot be found
@@ -35,7 +34,7 @@ type Client interface {
 	//
 	// The list of all hosts with their IP addresses is cached the first time this method is called. Use a new
 	// client instance to fetch a new list from the server.
-	GetVersionForIp(ip net.IP) (string, error)
+	GetVersionForIp(ip string) (string, error)
 }
 
 // Known OS values.
@@ -106,7 +105,7 @@ func (c *client) GetVersionForLatest(os, installerType string) (string, error) {
 }
 
 // GetVersionForIp returns the agent version running on the host with the given IP address.
-func (c *client) GetVersionForIp(ip net.IP) (string, error) {
+func (c *client) GetVersionForIp(ip string) (string, error) {
 	if len(ip) == 0 {
 		return "", errors.New("ip is invalid")
 	}
@@ -126,7 +125,7 @@ func (c *client) GetVersionForIp(ip net.IP) (string, error) {
 		}
 	}
 
-	switch v, ok := c.hostCache[ip.String()]; {
+	switch v, ok := c.hostCache[ip]; {
 	case !ok:
 		return "", errors.New("host not found")
 	case v == "":

--- a/pkg/dynatrace-client/client_test.go
+++ b/pkg/dynatrace-client/client_test.go
@@ -1,7 +1,6 @@
 package dynatrace_client
 
 import (
-	"net"
 	"strings"
 	"testing"
 
@@ -67,11 +66,7 @@ func TestClient_GetVersionForIp(t *testing.T) {
 	}
 
 	{
-		_, err := c.GetVersionForIp(nil)
-		assert.Error(t, err, "nil IP")
-	}
-	{
-		_, err := c.GetVersionForIp(net.IP{})
+		_, err := c.GetVersionForIp("")
 		assert.Error(t, err, "empty IP")
 	}
 
@@ -141,9 +136,11 @@ const goodHostsResponse = `[
   }
 ]`
 
-var goodIp = net.IPv4(192, 168, 0, 1)
-var unsetIp = net.IPv4(192, 168, 100, 1)
-var unknownIp = net.IPv4(127, 0, 0, 1)
+const (
+	goodIp    = "192.168.0.1"
+	unsetIp   = "192.168.100.1"
+	unknownIp = "127.0.0.1"
+)
 
 func TestReadHostMap(t *testing.T) {
 	readFromString := func(json string) (map[string]string, error) {


### PR DESCRIPTION
This adds a cache for the host list, which is persistent for a particular client instance. I also moved the detailed documentation for the interface methods to the interface definition, because that's where I'd expect it to be.

The cache maps IP addresses (which are strings) to version strings. There's a trade off there in that we format version objects into version strings for all received hosts immediately. Instead we could store version objects and format them on demand, which would save computation time when building the map but probably take more memory to store. It really depends on the use case, if there can be multiple requests for the same IP or if we go through most hosts anyway, then it's fine as is. I'm happy to change this if you think it makes sense.