### PR TITLE
Use map for status.items

### DIFF
--- a/pkg/apis/dynatrace/v1alpha1/types.go
+++ b/pkg/apis/dynatrace/v1alpha1/types.go
@@ -30,12 +30,11 @@ type OneAgentSpec struct {
 	WaitReadySeconds *uint16           `json:"waitReadySeconds,omitempty"`
 }
 type OneAgentStatus struct {
-	Version          string             `json:"version,omitempty"`
-	Items            []OneAgentInstance `json:"items,omitempty"`
-	UpdatedTimestamp metav1.Time        `json:"updatedTimestamp,omitempty"`
+	Version          string                      `json:"version,omitempty"`
+	Items            map[string]OneAgentInstance `json:"items,omitempty"`
+	UpdatedTimestamp metav1.Time                 `json:"updatedTimestamp,omitempty"`
 }
 type OneAgentInstance struct {
-	PodName  string `json:"podName,omitempty"`
-	NodeName string `json:"nodeName,omitempty"`
-	Version  string `json:"version,omitempty"`
+	PodName string `json:"podName,omitempty"`
+	Version string `json:"version,omitempty"`
 }

--- a/pkg/apis/dynatrace/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/dynatrace/v1alpha1/zz_generated.deepcopy.go
@@ -124,8 +124,10 @@ func (in *OneAgentStatus) DeepCopyInto(out *OneAgentStatus) {
 	*out = *in
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]OneAgentInstance, len(*in))
-		copy(*out, *in)
+		*out = make(map[string]OneAgentInstance, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	in.UpdatedTimestamp.DeepCopyInto(&out.UpdatedTimestamp)
 	return


### PR DESCRIPTION
Introduces an incompatible change to `.status.items` by replacing the array by a map.