### PR TITLE
Add proper definition of container ports

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -263,6 +263,7 @@ func getDaemonSet(cr *v1alpha1.OneAgent) *appsv1.DaemonSet {
 							Privileged: &trueVar,
 						},
 						Ports: []corev1.ContainerPort{{
+							Name:          "watchdog-os",
 							ContainerPort: 50000,
 							Protocol:      "TCP",
 						}},


### PR DESCRIPTION
Added ports definition to podspec in order to support readinessprobes on GKE.