### PR TITLE
Changed ReadinessProbe to Exec

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -263,7 +263,7 @@ func getDaemonSet(cr *v1alpha1.OneAgent) *appsv1.DaemonSet {
 						ReadinessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								Exec: &corev1.ExecAction{
-									Command: []string{"pgrep", "oneagenthelper"},
+									Command: []string{"pgrep", "oneagentwatchdog"},
 								},
 							},
 							InitialDelaySeconds: 30,


### PR DESCRIPTION
Connecting to the watchdog port for testing the readiness of OneAgent is not
supported. Changed it to test for process `oneagentwatchdog` which is needed for
container injection to work.