### PR TITLE
Add namespace configuration at runtime

### DIFF
--- a/cmd/dynatrace-oneagent-operator/main.go
+++ b/cmd/dynatrace-oneagent-operator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"runtime"
 
 	stub "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/stub"
@@ -19,7 +20,9 @@ func printVersion() {
 
 func main() {
 	printVersion()
-	sdk.Watch("dynatrace.com/v1alpha1", "OneAgent", "dynatrace", 120)
+	namespace := os.Getenv("MY_POD_NAMESPACE")
+	logrus.Infof("watching namespace: %v", namespace)
+	sdk.Watch("dynatrace.com/v1alpha1", "OneAgent", namespace, 120)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -26,3 +26,8 @@ spec:
           command:
           - dynatrace-oneagent-operator
           imagePullPolicy: Always
+          env:
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace


### PR DESCRIPTION
Change to dynamic namespace configuration at runtime in order to be able to
deploy the Operator in any given namespace.

Resolves #15