### PR TITLE
Reduce permissions to the max

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -8,11 +8,35 @@ metadata:
     operator: oneagent
 rules:
 - apiGroups:
-  - "*"
+  - dynatrace.com
   resources:
-  - "*"
+  - oneagents
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -18,7 +18,6 @@ rules:
   - update
 - apiGroups:
   - apps
-  - extensions
   resources:
   - daemonsets
   verbs:
@@ -29,7 +28,7 @@ rules:
   - update
   - delete
 - apiGroups:
-  - ""
+  - "" # "" indicates the core API group
   resources:
   - pods
   verbs:


### PR DESCRIPTION
Reduce RBAC permissions to the bare minimum in order to restrict access to
objects operated on by a defined set of operations.

Resolves #16 