### PR TITLE
Secure access token via secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,14 @@ kind: "OneAgent"
 metadata:
   # a descriptive name for this object.
   # all created child objects will be based on it.
-  name: "example"
+  name: "oneagent"
   namespace: "dynatrace"
 spec:
   # dynatrace api url including `/api` path at the end
   apiUrl: "https://ENVIRONMENTID.live.dynatrace.com/api"
-  # dynatrace api token: `/#settings/integration/apikeys`
-  apiToken: ""
-  # dynatrace paas token (aka installer token): `/#settings/integration/paastokens`
-  paasToken: ""
+  # name of secret holding `apiToken` and `paasToken`
+  # if unset, name of custom resource is used
+  tokens: ""
   # node selector to control the selection of nodes (optional)
   nodeSelector: {}
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ (optional)
@@ -72,7 +71,23 @@ spec:
   image: ""
 ```
 Save the snippet to a file or use [./deploy/cr.yaml](https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/cr.yaml) from this repository and adjust its values accordingly.
-To create the OneAgent custom resource run either `oc create -f cr.yaml` or `kubectl create -f cr.yaml`.
+A secret holding tokens for authenticating to the Dynatrace cluster needs to be created upfront.
+Create access tokens of type *Dynatrace API* and *Platform as a Service* and use its values in the following commands respectively.
+For assistance please refere to [Create user-generated access tokens](https://www.dynatrace.com/support/help/get-started/introduction/why-do-i-need-an-access-token-and-an-environment-id/#create-user-generated-access-tokens).
+
+Note: `.spec.tokens` denotes the name of the secret holding access tokens. If not specified OneAgent Operator searches for a secret called like the OneAgent custom resource (`.metadata.name`).
+
+##### Kubernetes
+```sh
+$ kubectl create secret generic oneagent --from-literal="apiToken=DYNATRACE_API_TOKEN" --from-literal="paasToken=PLATFORM_AS_A_SERVICE_TOKEN"
+$ kubectl create -f cr.yaml
+```
+
+##### OpenShift
+```sh
+$ oc create secret generic oneagent --from-literal="apiToken=DYNATRACE_API_TOKEN" --from-literal="paasToken=PLATFORM_AS_A_SERVICE_TOKEN"
+$ oc create -f cr.yaml
+```
 
 
 ## Uninstall dynatrace-oneagent-operator

--- a/pkg/apis/dynatrace/v1alpha1/types.go
+++ b/pkg/apis/dynatrace/v1alpha1/types.go
@@ -24,8 +24,6 @@ type OneAgent struct {
 
 type OneAgentSpec struct {
 	ApiUrl           string              `json:"apiUrl"`
-	ApiToken         string              `json:"apiToken"`
-	PaasToken        string              `json:"paasToken"`
 	SkipCertCheck    bool                `json:"skipCertCheck,omitempty"`
 	NodeSelector     map[string]string   `json:"nodeSelector,omitempty"`
 	Tolerations      []corev1.Toleration `json:"tolerations,omitempty"`
@@ -33,11 +31,15 @@ type OneAgentSpec struct {
 	// Installer image
 	// Defaults to docker.io/dynatrace/oneagent:latest
 	Image string `json:"image,omitempty"`
+	// Name of secret containing tokens
+	// Secret must contain keys `apiToken` and `paasToken`
+	Tokens string `json:"tokens"`
 }
 type OneAgentStatus struct {
 	Version          string                      `json:"version,omitempty"`
 	Items            map[string]OneAgentInstance `json:"items,omitempty"`
 	UpdatedTimestamp metav1.Time                 `json:"updatedTimestamp,omitempty"`
+	Tokens           string                      `json:"tokens,omitempty"`
 }
 type OneAgentInstance struct {
 	PodName string `json:"podName,omitempty"`

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -55,15 +55,17 @@ func (h *Handler) Handle(ctx types.Context, event types.Event) error {
 			return err
 		}
 
-		// get tokens for api access
-		if oneagent.Status.Tokens == "" || oneagent.Spec.Tokens != "" && oneagent.Status.Tokens != oneagent.Spec.Tokens {
-			if oneagent.Spec.Tokens != "" {
-				oneagent.Status.Tokens = oneagent.Spec.Tokens
-			} else {
-				oneagent.Status.Tokens = oneagent.Name
-			}
+		// update status.tokens
+		newTokens := oneagent.Name
+		if oneagent.Spec.Tokens != "" {
+			newTokens = oneagent.Spec.Tokens
+		}
+		if oneagent.Status.Tokens != newTokens {
+			oneagent.Status.Tokens = newTokens
 			updateStatus = true
 		}
+
+		// get access tokens for api authentication
 		paasToken, err := getSecretKey(oneagent, "paasToken")
 		if err != nil {
 			logrus.WithFields(logrus.Fields{"oneagent": oneagent.Name, "error": err, "token": "paasToken"}).Warning("failed to get token")


### PR DESCRIPTION
Plain text access tokens in CR got replaced by a secret holding `apiToken` and
`paasToken`. Name of the secret to use is depicted by `.spec.tokens`. If this
field is empty the name of the CR is used to look up the secret.