### PR TITLE
Add means to pass arguments and environemnt variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ spec:
   tolerations: []
   # oneagent installer image (optional)
   image: ""
+  # arguments to oneagent installer (optional)
+  # https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
+  # default: APP_LOG_CONTENT_ACCESS=1
+  args: []
+  # environment variables for oneagent (optional)
+  env: []
 ```
 Save the snippet to a file or use [./deploy/cr.yaml](https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/cr.yaml) from this repository and adjust its values accordingly.
 A secret holding tokens for authenticating to the Dynatrace cluster needs to be created upfront.

--- a/pkg/apis/dynatrace/v1alpha1/defaults.go
+++ b/pkg/apis/dynatrace/v1alpha1/defaults.go
@@ -9,4 +9,8 @@ func SetDefaults_OneAgentSpec(obj *OneAgentSpec) {
 	if obj.Image == "" {
 		obj.Image = "docker.io/dynatrace/oneagent:latest"
 	}
+
+	if len(obj.Args) == 0 {
+		obj.Args = append(obj.Args, "APP_LOG_CONTENT_ACCESS=1")
+	}
 }

--- a/pkg/apis/dynatrace/v1alpha1/types.go
+++ b/pkg/apis/dynatrace/v1alpha1/types.go
@@ -34,6 +34,10 @@ type OneAgentSpec struct {
 	// Name of secret containing tokens
 	// Secret must contain keys `apiToken` and `paasToken`
 	Tokens string `json:"tokens"`
+	// Arguments to the installer.
+	Args []string `json:"args,omitempty"`
+	// List of environment variables to set for the installer.
+	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 type OneAgentStatus struct {
 	Version          string                      `json:"version,omitempty"`

--- a/pkg/apis/dynatrace/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/dynatrace/v1alpha1/zz_generated.deepcopy.go
@@ -114,6 +114,18 @@ func (in *OneAgentSpec) DeepCopyInto(out *OneAgentSpec) {
 			**out = **in
 		}
 	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Optional arguments and environment variables may be passed to OneAgent
installer via fields `.spec.args` and `.spec.env` respectively.

args: array of strings
env:  array of struct with fields `name` and `value`