### PR TITLE
Synchronize changes between CR and DS

### DIFF
--- a/pkg/apis/dynatrace/v1alpha1/defaults.go
+++ b/pkg/apis/dynatrace/v1alpha1/defaults.go
@@ -1,5 +1,12 @@
 package v1alpha1
 
+import (
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
 func SetDefaults_OneAgentSpec(obj *OneAgentSpec) {
 	if obj.WaitReadySeconds == nil {
 		obj.WaitReadySeconds = new(uint16)
@@ -12,5 +19,29 @@ func SetDefaults_OneAgentSpec(obj *OneAgentSpec) {
 
 	if len(obj.Args) == 0 {
 		obj.Args = append(obj.Args, "APP_LOG_CONTENT_ACCESS=1")
+	}
+
+	if _, ok := obj.NodeSelector["beta.kubernetes.io/os"]; !ok {
+		obj.NodeSelector["beta.kubernetes.io/os"] = "linux"
+	}
+
+	// temporary map for easy lookup of entries in obj.Env
+	env := make(map[string]int)
+	for i, e := range obj.Env {
+		env[e.Name] = i
+	}
+	if _, ok := env["ONEAGENT_INSTALLER_SCRIPT_URL"]; !ok {
+		obj.Env = append(obj.Env, corev1.EnvVar{
+			Name:  "ONEAGENT_INSTALLER_SCRIPT_URL",
+			Value: fmt.Sprintf("%s/v1/deployment/installer/agent/unix/default/latest?Api-Token=%s&arch=x86&flavor=default", obj.ApiUrl, "$(ONEAGENT_INSTALLER_TOKEN)"),
+		})
+	}
+	if i, ok := env["ONEAGENT_INSTALLER_SKIP_CERT_CHECK"]; !ok {
+		obj.Env = append(obj.Env, corev1.EnvVar{
+			Name:  "ONEAGENT_INSTALLER_SKIP_CERT_CHECK",
+			Value: strconv.FormatBool(obj.SkipCertCheck),
+		})
+	} else {
+		obj.Env[i].Value = strconv.FormatBool(obj.SkipCertCheck)
 	}
 }

--- a/pkg/apis/dynatrace/v1alpha1/types.go
+++ b/pkg/apis/dynatrace/v1alpha1/types.go
@@ -43,7 +43,6 @@ type OneAgentStatus struct {
 	Version          string                      `json:"version,omitempty"`
 	Items            map[string]OneAgentInstance `json:"items,omitempty"`
 	UpdatedTimestamp metav1.Time                 `json:"updatedTimestamp,omitempty"`
-	Tokens           string                      `json:"tokens,omitempty"`
 }
 type OneAgentInstance struct {
 	PodName string `json:"podName,omitempty"`


### PR DESCRIPTION
Add support for updating a DaemonSet in case a change was made either in the
OneAgent custom resource or in the DaemonSet itself.

* Refactor logic for building DaemonSet objects.

* Move default value computation to defaulter funcs.

* Refactor computation of ONEAGENT_INSTALLER_TOKEN and purge dependency on
  .status.tokens.