### PR TITLE
Fix bug on empty nodeSelector field

### DIFF
--- a/pkg/apis/dynatrace/v1alpha1/defaults.go
+++ b/pkg/apis/dynatrace/v1alpha1/defaults.go
@@ -18,6 +18,9 @@ func SetDefaults_OneAgentSpec(obj *OneAgentSpec) {
 	}
 
 	if _, ok := obj.NodeSelector["beta.kubernetes.io/os"]; !ok {
+		if obj.NodeSelector == nil {
+			obj.NodeSelector = make(map[string]string)
+		}
 		obj.NodeSelector["beta.kubernetes.io/os"] = "linux"
 	}
 

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -1,8 +1,10 @@
 package stub
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
@@ -42,6 +44,11 @@ func (h *Handler) Handle(ctx types.Context, event types.Event) error {
 		if event.Deleted {
 			logrus.WithFields(logrus.Fields{"oneagent": oneagent.Name}).Info("object deleted")
 			return nil
+		}
+
+		if err := validateOneAgent(oneagent); err != nil {
+			logrus.WithFields(logrus.Fields{"oneagent": oneagent.Name, "error": err}).Error("failed to assert fields")
+			return errors.New("failed to assert essential custom resource fields")
 		}
 
 		updateStatus := false
@@ -457,4 +464,19 @@ func getDaemonSet(cr *v1alpha1.OneAgent) *appsv1.DaemonSet {
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
 		}}
+}
+
+// validateOneAgent sanity checks if essential fields in the custom resource are available
+//
+// Return an error in the following conditions
+// - ApiUrl empty
+func validateOneAgent(cr *v1alpha1.OneAgent) error {
+	var msg []string
+	if len(cr.Spec.ApiUrl) == 0 {
+		msg = append(msg, ".spec.apiUrl is missing")
+	}
+	if len(msg) > 0 {
+		return errors.New(strings.Join(msg, ", "))
+	}
+	return nil
 }


### PR DESCRIPTION
* Fixes a panic in defaulter function if `.spec.nodeSelector` is empty.
* Add sanity check for essential fields. Currently this coveres `.spec.apiUrl`.