### PR TITLE
Add a service account for OneAgent pods

### DIFF
--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -14,6 +14,12 @@ metadata:
   name: dynatrace-oneagent-operator
   namespace: dynatrace
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-oneagent
+  namespace: dynatrace
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -17,11 +17,17 @@ metadata:
   namespace: dynatrace
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-oneagent
+  namespace: dynatrace
+---
+apiVersion: v1
 kind: SecurityContextConstraints
 metadata:
   annotations:
-    kubernetes.io/description: 'dynatrace-privileged allows access to all privileged and host features and the ability to run as any user, any group, any fsGroup, and with any SELinux context. This is a copy of privileged scc.'
-  name: dynatrace-privileged
+    kubernetes.io/description: 'dynatrace-oneagent-privileged allows access to all privileged and host features and the ability to run as any user, any group, any fsGroup, and with any SELinux context. This is a copy of privileged scc.'
+  name: dynatrace-oneagent-privileged
 allowHostDirVolumePlugin: true
 allowHostIPC: true
 allowHostNetwork: true
@@ -34,8 +40,6 @@ allowedFlexVolumes: null
 defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
-groups:
-- system:cluster-admins
 priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities: null
@@ -48,7 +52,7 @@ seccompProfiles:
 supplementalGroups:
   type: RunAsAny
 users:
-- system:serviceaccount:dynatrace:default
+- system:serviceaccount:dynatrace:dynatrace-oneagent
 volumes:
 - '*'
 ---

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -390,6 +390,7 @@ func applyOneAgentDefaults(ds *appsv1.DaemonSet, cr *v1alpha1.OneAgent) {
 						PeriodSeconds:       30,
 					},
 				}},
+				ServiceAccountName: "dynatrace-oneagent",
 			},
 		},
 	}


### PR DESCRIPTION
OneAgent pods should use its own service account in order to implement security best practices.