### PR TITLE
Add RedHat Connect and Container Catalog support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,13 @@ jobs:
       - checkout
       - run: dep ensure -v
       - run: go test -cover ./...
-      - run: |
-          SDK=$(dep status | grep github.com/operator-framework/operator-sdk | awk '{print $3}')
-          mkdir -p /go/src/github.com/operator-framework
-          cd /go/src/github.com/operator-framework/
-          git clone -b $SDK https://github.com/operator-framework/operator-sdk.git
-          cd operator-sdk
-          dep ensure -v
-          go install github.com/operator-framework/operator-sdk/commands/operator-sdk
-      - setup_remote_docker
-      - run: operator-sdk build $OAO_IMAGE:$CIRCLE_WORKFLOW_ID
-      - run: docker save -o $CIRCLE_WORKFLOW_ID.tar $OAO_IMAGE:$CIRCLE_WORKFLOW_ID
+      - run: ./tmp/build/build.sh
       - persist_to_workspace:
           root: .
           paths:
-            - "*.tar"
+            - LICENSE
+            - tmp/_output/bin/dynatrace-oneagent-operator
+            - tmp/build/*
 
   deploy-snapshot:
     <<: *defaults
@@ -43,10 +35,11 @@ jobs:
           base64 -d >~/.docker/config.json <<<"$OAO_DOCKER_AUTH"
       - attach_workspace:
           at: .
-      - run: docker load -i $CIRCLE_WORKFLOW_ID.tar
-      - run: |
-          docker tag $OAO_IMAGE:$CIRCLE_WORKFLOW_ID $OAO_IMAGE:snapshot
-          docker push $OAO_IMAGE:snapshot
+      - run:
+          environment:
+            DOCKERFILE: ./tmp/build/Dockerfile
+          command: IMAGE=$OAO_IMAGE:snapshot ./tmp/build/docker_build.sh
+      - run: docker push $OAO_IMAGE:snapshot
 
   deploy-release:
     <<: *defaults
@@ -58,13 +51,27 @@ jobs:
           base64 -d >~/.docker/config.json <<<"$OAO_DOCKER_AUTH"
       - attach_workspace:
           at: .
-      - run: docker load -i $CIRCLE_WORKFLOW_ID.tar
+      - run:
+          environment:
+            DOCKERFILE: ./tmp/build/Dockerfile
+          command: IMAGE=$OAO_IMAGE:$CIRCLE_TAG ./tmp/build/docker_build.sh
+      - run: docker push $OAO_IMAGE:$CIRCLE_TAG
+
+  deploy-release-rhcc:
+    <<: *defaults
+    steps:
+      - setup_remote_docker
       - run: |
-          docker tag $OAO_IMAGE:$CIRCLE_WORKFLOW_ID $OAO_IMAGE:$CIRCLE_TAG
-          docker push $OAO_IMAGE:$CIRCLE_TAG
-      - run: |
-          docker tag $OAO_IMAGE:$CIRCLE_WORKFLOW_ID $OAO_IMAGE:latest
-          docker push $OAO_IMAGE:latest
+          mkdir -p ~/.docker && chmod 0700 ~/.docker
+          touch ~/.docker/config.json && chmod 0600 ~/.docker/config.json
+          base64 -d >~/.docker/config.json <<<"$OAO_DOCKER_AUTH_RHCC"
+      - attach_workspace:
+          at: .
+      - run:
+          environment:
+            DOCKERFILE: ./tmp/build/Dockerfile-rhel
+          command: IMAGE=$OAO_IMAGE_RHCC:$CIRCLE_TAG ./tmp/build/docker_build.sh
+      - run: docker push $OAO_IMAGE_RHCC:$CIRCLE_TAG
 
 
 workflows:
@@ -82,6 +89,14 @@ workflows:
             branches:
               only: /^master$/
       - deploy-release:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - deploy-release-rhcc:
           requires:
             - build
           filters:

--- a/tmp/build/Dockerfile-rhel
+++ b/tmp/build/Dockerfile-rhel
@@ -14,7 +14,4 @@ COPY LICENSE /licenses/
 
 ADD tmp/_output/bin/dynatrace-oneagent-operator /usr/local/bin/dynatrace-oneagent-operator
 
-RUN microdnf install ca-certificates shadow-utils --enablerepo=rhel-7-server-rpms \
-    && useradd dynatrace-oneagent-operator
-
-USER dynatrace-oneagent-operator
+USER 1001:1001

--- a/tmp/build/docker_build.sh
+++ b/tmp/build/docker_build.sh
@@ -6,6 +6,7 @@ if ! which docker > /dev/null; then
 fi
 
 : ${IMAGE:?"Need to set IMAGE, e.g. gcr.io/<repo>/<your>-operator"}
+: ${DOCKERFILE:="tmp/build/Dockerfile"}
 
 echo "building container ${IMAGE}..."
-docker build -t "${IMAGE}" -f tmp/build/Dockerfile .
+docker build -t "${IMAGE}" -f "${DOCKERFILE}" .


### PR DESCRIPTION
In addition to the image hosted on quay.io a RedHat certified image gets
published on RedHat Container Catalog each time a release is built.