### PR TITLE
Supply ClusterServiceVersion for Operator Lifecycle Manager

### DIFF
--- a/deploy/dynatrace-monitoring.v0.2.0.clusterseviceversion.yaml
+++ b/deploy/dynatrace-monitoring.v0.2.0.clusterseviceversion.yaml
@@ -1,0 +1,162 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"dynatrace.com/v1alpha1","kind":"OneAgent","metadata":{"name":"oneagent"},"spec":{"apiUrl":"https://ENVIRONMENTID.live.dynatrace.com/api","args":["APP_LOG_CONTENT_ACCESS=1"],"image":"registry.connect.redhat.com/dynatrace/oneagent"}}]'
+  generation: 1
+  labels:
+    alm-catalog: certified-operators
+  name: dynatrace-monitoring.v0.2.0
+  namespace: ""
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Dyantrace OneAgent monitoring agent
+      displayName: Dynatrace OneAgent
+      kind: OneAgent
+      name: oneagents.dynatrace.com
+      resources:
+      - kind: DaemonSet
+        name: ""
+        version: v1beta2
+      - kind: Pod
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: Credentials for the OneAgent to connect back to Dynatrace.
+        displayName: API and Pass Tokens
+        path: tokens
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:core:v1:Secret
+      - description: '''Location of the Dynatrace API to connect to, including your
+          specific environment ID'''
+        displayName: API URL
+        path: apiUrl
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
+      version: v1alpha1
+  description: |
+    Install full-stack monitoring of [Kubernetes clusters](https://www.dynatrace.com/technologies/kubernetes-monitoring/) with the Dynatrace OneAgent on your cluster. OneAgent connects back to Dynatrace's hosted monitoring tools.
+    ## Before Your Start
+
+    Add a Secret within the Project that contians your API and PaaS tokens.  Create tokens of type *Dynatrace API* (`API_TOKEN`) and *Platform as a Service* (`PAAS_TOKEN`) and use its values in the following commands respectively.  For assistance please refere to [Create user-generated access tokens](https://www.dynatrace.com/support/help/get-started/introduction/why-do-i-need-an-access-token-and-an-environment-id/#create-user-generated-access-tokens).
+
+    ``` $ kubectl -n dynatrace create secret generic oneagent --from-literal="apiToken=API_TOKEN" --from-literal="paasToken=PAAS_TOKEN" ```
+
+    You may update this Secret at any time to rotate the tokens.
+    ## Required Parameters
+    * `apiUrl` - provide the environment ID used in conjuction with this monitoring agent in the API adddress, eg `https://<ENVIRONMENTID>.live.dynatrace.com/api`
+    ## Advanced Options ##
+    **Image Override** - use a copy of the OneAgent container image from a registry other than Quay`s or Red Hat's
+
+    **NodeSelectors** - select a subset of your cluster's Nodes to run OneAgent on, based on labels
+
+    **Tolerations** - add specific tolerations to the agent so that it can monitor all of the Nodes in your cluster
+
+    **Disable Certificate Checking** - disable any certificate validation that may interact poorly with proxies with in your cluster
+
+    For a complete list of supported parameters please consult the [Operator Deploy Guide](https://www.dynatrace.com/support/help/shortlink/openshift-deploy#parameters).
+  displayName: Dynatrace OneAgent
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAANcAAADKCAMAAAAB6yXCAAABsFBMVEVMaXEaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhq03AAaGhpzvigaGhoUlv8aGhpvLai03AC03ABzvihzvihzvihzvii03AAaGhpzvihzvii03AC03ABzvii03AC03ABvLagUlv8Ulv9vLai03AAUlv9zvihvLagUlv8Ulv8Ulv9vLai03ABvLagUlv9vLagUlv9vLahvLai03ABvLahzvihvLai03ABvLahzvihzvihzvigUlv8Ulv+03ABzvihvLagTjPNzvii03ACx2wRvLagUlv8TkflvLagUlv8Ulv8Ulv+03ABuj0tiJZtjJpyUzC8TjPRsiFBzuiuu2gmv2ghCpq5jtX1zvii03AAUlv9vLagaGhoShOpZH5FeIpcTjfQSiO87mq9tl0JjsHWMxjpmb1xgR3dpg09bKYpjW2lxtS5cIZRuLKcUlPxPpZISh+5pKaIcitthUXCg0RxuoTtwqzVaIJIwlb6WzCsShu1gI5hkJpxoKaF4u1drWHtfNYZdIpVsK6VrjUlnKJ8Tkfqq1w4Tjvag0h2CwUgeme5QqZcTivFttmaCyVeZAAAAWnRSTlMAoCDQ8GAQwIBA4DCAsEBQQHDA8EAwgPDAEJDQEKBgoMAwQMCAgNAwYKBg8NAQsNCg8BBgIHAwUJAgcHCwkCCQ4OBQcCCQ07Bw3OCwUOBQuHA87zz41qb4bYKEG2nxAAAACXBIWXMAAAsSAAALEgHS3X78AAAHSElEQVR42u3bd2PTRhgHYG1ZHjh2nIEhjuPEzDSFQkrCKrN778qxQ5sABUoZpXvv3X7l6jRPp2ENNzqL9/cHSWxZd4/G3XsiYRgIBAKBQCAQCAQCgUAgEAgEQnsarXJDS75Q63OTPTvn2u25cvnFHBhbmMqVc+2V8urYAlu9odF96+PFWu1Fzr52udXYPR6suV7cTLYvr1Kvi8+ydeXWev5YOm0BWDuZ3Sv5ZO1Lw9pnsvbmjGUOiPPT+WSp0zlk7T2tqrNUsRYmR8Hao1LmSsdawViqmhvWHIOz1Jyy1F3ULI1HwZqyWNS4Wr1RsGYslnoqD6xVD4uSCSwdq+VlqfP5ZFExgZVHwTrhYql7xny5ZbEOqETGfBXZCGCp481aCGKpU/lkZTsxj2bNf8aHpZ7IkvVkUJe/fLXdbq+Uyaxor7YnCda8HyvLiZlgfXL9+rVr97a3v9jUcjH8k41Gq7wexsrSddnwIM729oNNVy5G3UkAK8OCo6GZfvtue9M3r6VkZVhwvNnr/flgMyDRdrF3VqXP9VbvHhJ8tbX1npOtra370V3TgazsCqmF3r+b93//dcMvd59J7cqs4Gj88c/djaAsjq/rnb83NtK6TlDoevuvENeRaPvYFeLKqpCaCGFtLIELXBS4DqV3TdPomhhfFwMucD0ErlkaXftz6mLARZ1rOaeuxfSuUzl1ha0rz+fUpYJrtHkip66l9K75nLpmwbVzOZS+7qXSNZHedT6nLvUhdM1k5WJSr78uhblO0+c6/Hz6cj7D/zgPZEVcLdO5TAksECOzwpYpM1O0uSzWWr2+1u1e6HQ6x/0//srLL1HJYp4LYx3se1I38iz6/grKTSpZvoXU8tlAliufI9dVKll+ruXHorH67yLXp1SyfApEk/VIvR/JFfCbABmzvAWHxXq0H8l1y5+V+d9I7U/O0l036GSRE/ORGCzd9TGlLMbvVwCisXTX+5SyXE98TdbjR/uRXd7p6zQdf3+4mJilu67S87t5QU/a4rJ0121KWc7E/HRclu6ilWVPzOZvNXSis5DrBq0sa2I2Wcf6/ViuD2hlMWcTs/ofEsP8AYamJGb1ieGQLhbzwsbhiUQs5PqMWhazaK0iuzFZd1zDIW0sZml/xOUWmY/w4ZA6lpXYrP63znA4sys/rP439nCY9eJ4pKz+19ZwSC9rLQFLm75uUc7SVlydkwfr8Vg/mZchzSwzxzvd6Lpfrty6TcMTmjjnrlsfvmL+8crP1CyO4528k92n6keDZ6+bY8nCfBe63Tp5Au/8gMbCM+PLcgk7x7rdtbqG/P51VX3jzCUGAoFAIBAIBAKBQCAQCAQCCYg8GBRS76QwGMjgAhe4wAUuf5eiZ2cxClscOCkwVe1fCd9AEgYDUf+mVhHQNnzT7qJifU6Qa5ztMmLqOFYwX8DfLFZErBGx4vTBaLMmm02VkqlK8sAV7XxpTdTwTUSt1+hrTXA2kznCZX7W66oO8B4XsM0FqxUFP7C6q4A3JSVh6TsoykYEvW9N7TARVyerfWGN4yzzRqdK5mExwjuSAjp5KE3rZJs/o3dFc3tDwlrHDeuDbDfFyzLeVJzorRY49/3Faa9huzJ/rKG2jWunWhkQdPQiojU99xfqdM2vZVEw3ymhrhfwk4Ka4kXjuLE+TUW6x41bxzVuyNaR1GOePq0bvIT3ViR3hrQc6WIDR0eJN67viueMaE1VmNCmhqXoElgu64ayt6kZtwnn2rLid/JrpCtkiEUnqspInn5rTQlSeFPD4r7irE7YA6B130t6byvutgeevTX1bSK7GB69p3j25G1KiDvEE/u0OoFfPBXjlBbc/VP8XKL+seiugumSPdfz0KaSuRTnopP0iyWaSxmNS/7fXOieKthjU5EJdUmKlVokF2dvzwa6WEXB9zoyl6VxhAEupeKe1oe5qjxZBvi6yIzKxZlXn3NF+rtEsgNDXCy5/Q67rNHCGUF8XZxZFjhFR7hLr7rszeVioKsouzMylzm6OyO+rwuVTEqMcUM7WkUu7riRpJQPdDEGyJmhfV2yUTlFdgnm1Z2hy6ieeLseCXJV47jcNUvE+StJ/OsNu9rFKuAglxLT5Td/hdcbSeJfH1pFThNbsUQ5X4WY56uJ3vPWh6K7Pky4Zsd3iteFaO+Cs8aIcn+x+oF25j6/+0sk60NvPS8JqU+Yvv5irZKJxY+nZMwcUpgLHRbFtWyqGWU6GzgeYoSm8Wlj/UXcdwO+mgqGr5exZxL2HMoyYS6OWGwb1w/vrJBLblcVn+/Q9sUh62U9YiKYa3bnJXfXndsnWr0hOsdKjxJeb5gnz/t8o+l9bJLgeZRVs/Gu1TgaVIpMuMtdH1ZK5BMoJaw+FFj74hNZ4nkU15TTusIGywJeheO3gOQ8DrTqc86naPcb1kpK8Hs78lyRGJXzEpa+59GjiCQkeA40BhHjPy4Zi7gfIuYmxENfCAQCgUAgEAgEAoFAIBAIBJLX/AcIuMeF+5wRowAAAABJRU5ErkJggg==
+    mediatype: ""
+  install:
+    spec:
+      deployments:
+      - name: dynatrace-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: dynatrace-oneagent-operator
+          template:
+            metadata:
+              labels:
+                dynatrace: operator
+                name: dynatrace-oneagent-operator
+                operator: oneagent
+            spec:
+              containers:
+              - command:
+                - dynatrace-oneagent-operator
+                env:
+                - name: MY_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: quay.io/dynatrace/dynatrace-oneagent-operator:v0.2.0
+                imagePullPolicy: Always
+                name: dynatrace-oneagent-operator
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 128Mi
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+              nodeSelector:
+                beta.kubernetes.io/os: linux
+              serviceAccountName: dynatrace-oneagent-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - dynatrace.com
+          resources:
+          - oneagents
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - dynatrace.com
+          resources:
+          - oneagents/finalizers
+          verbs:
+          - update
+        serviceAccountName: dynatrace-oneagent-operator
+    strategy: deployment
+  keywords:
+  - monitoring
+  links:
+  - name: Operator Deploy Guide
+    url: https://www.dynatrace.com/support/help/shortlink/kubernetes-deploy
+  - name: OpenShift Monitoring Info
+    url: https://www.dynatrace.com/technologies/kubernetes-monitoring/
+  maintainers:
+  - email: support@dynatrace.com
+    name: Dynatrace LLC
+  maturity: stable
+  provider:
+    name: Dynatrace LLC
+  version: 0.2.0
+  replaces: ""


### PR DESCRIPTION
The provided ClusterServiceVersion for OneAgent Operator v0.2.0 can be used on
Kubernetes.