### PR TITLE
Adding a helm chart for deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ Help topic _How do I deploy Dynatrace OneAgent as a Docker container?_ lists com
 The Dynatrace OneAgent Operator acts on its separate namespace `dynatrace`.
 It holds the operator deployment and all dependent objects like permissions, custom resources and
 corresponding DaemonSets.
-Create neccessary objects and observe its logs:
+
+#### Helm
+Create a [values.yaml](deploy/helm-chart/values.yaml) file and ensure it contains your apiToken, paasToken, and apiURL.  Then:
+```sh
+$ helm install -f values.yaml --name dynatrace-oneagent --namespace dynatrace ./deploy/helm-chart
+```
+
+To install manually, create neccessary objects and observe its logs:
 
 #### Kubernetes
 ```sh
@@ -120,7 +127,14 @@ $ oc create -f cr.yaml
 
 
 ## Uninstall dynatrace-oneagent-operator
-Remove OneAgent custom resources and clean-up all remaining OneAgent Operator specific objects:
+
+#### Helm
+```sh
+$ helm delete dynatrace-oneagent
+$ kubectl delete crd oneagents.dynatrace.com --namespace dynatrace
+```
+
+To remove OneAgent custom resources and clean-up all remaining OneAgent Operator specific objects manually:
 
 
 #### Kubernetes

--- a/deploy/helm-chart/.helmignore
+++ b/deploy/helm-chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/helm-chart/Chart.yaml
+++ b/deploy/helm-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.2.0"
+description: Setup a Dynatrace daemon set in a Kubernetes cluster
+name: dynatrace-oneagent
+version: 0.1.0

--- a/deploy/helm-chart/templates/_helpers.tpl
+++ b/deploy/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dynatrace-oneagent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dynatrace-oneagent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dynatrace-oneagent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/helm-chart/templates/crd-OneAgent.yaml
+++ b/deploy/helm-chart/templates/crd-OneAgent.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: oneagents.dynatrace.com
+  labels:
+    app: {{ template "dynatrace-oneagent.name" . }}
+    chart: {{ template "dynatrace-oneagent.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": crd-install
+spec:
+  group: dynatrace.com
+  names:
+    kind: OneAgent
+    listKind: OneAgentList
+    plural: oneagents
+    singular: oneagent
+  scope: Namespaced
+  version: v1alpha1

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dynatrace-oneagent-operator
+  labels:
+    dynatrace: operator
+    operator: oneagent
+    app: {{ template "dynatrace-oneagent.name" . }}
+    chart: {{ template "dynatrace-oneagent.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      name: dynatrace-oneagent-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: dynatrace-oneagent-operator
+        dynatrace: operator
+        operator: oneagent
+    spec:
+      containers:
+        - name: dynatrace-oneagent-operator
+          image: quay.io/dynatrace/dynatrace-oneagent-operator:v0.2.0
+          command:
+          - dynatrace-oneagent-operator
+          imagePullPolicy: Always
+          env:
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        beta.kubernetes.io/arch: amd64
+      serviceAccountName: dynatrace-oneagent-operator

--- a/deploy/helm-chart/templates/oneagent-operator.yaml
+++ b/deploy/helm-chart/templates/oneagent-operator.yaml
@@ -34,13 +34,49 @@ spec:
   # arguments to oneagent installer (optional)
   # https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
   args:
-  {{- range $key, $value := .Values.operator.args }}
-    {{- if $value }}
-    - --{{ $key }}={{ $value }}
-    {{- else }}
-    - --{{ $key }}
+    {{- if .Values.operator.args.server }}
+    - SERVER={{ .Values.operator.args.server }}
     {{- end }}
-  {{- end }}
+    {{- if .Values.operator.args.tenant }}
+    - TENANT={{ .Values.operator.args.tenant }}
+    {{- end }}
+    {{- if .Values.operator.args.tenantToken }}
+    - TENANT_TOKEN={{ .Values.operator.args.tenantToken }}
+    {{- end }}
+    {{- if .Values.operator.args.proxy }}
+    - PROXY={{ .Values.operator.args.proxy }}
+    {{- end }}
+    {{- if .Values.operator.args.hostGroup }}
+    - HOST_GROUP={{ .Values.operator.args.hostGroup }}
+    {{- end }}
+    {{- if .Values.operator.args.installPath }}
+    - INSTALL_PATH={{ .Values.operator.args.installPath }}
+    {{- end }}
+    {{- if .Values.operator.args.infraOnly }}
+    - INFRA_ONLY={{ .Values.operator.args.infraOnly }}
+    {{- end }}
+    {{- if .Values.operator.args.noSELinuxPolicy }}
+    - -n
+    {{- end }}
+    {{- if .Values.operator.args.preserveSELinux }}
+    - -p
+    {{- end }}
+    {{- if .Values.operator.args.user }}
+    - USER={{ .Values.operator.args.user }}
+    {{- end }}
+    {{- if .Values.operator.args.group }}
+    - GROUP={{ .Values.operator.args.group }}
+    {{- end }}
+    {{- if .Values.operator.args.appLogContentAccess }}
+    - APP_LOG_CONTENT_ACCESS={{ .Values.operator.args.appLogContentAccess }}
+    {{- end }}
+    {{- if .Values.operator.args.nonRootMode }}
+    - NON_ROOT_MODE={{ .Values.operator.args.nonRootMode }}
+    {{- end }}
+    {{- if .Values.operator.args.disableRootFallback }}
+    - DISABLE_ROOT_FALLBACK={{ .Values.operator.args.disableRootFallback }}
+    {{- end }}
+    {{- end }}
   # environment variables for oneagent (optional)
   env:
   {{- range $name, $value := .Values.operator.env }}

--- a/deploy/helm-chart/templates/oneagent-operator.yaml
+++ b/deploy/helm-chart/templates/oneagent-operator.yaml
@@ -1,0 +1,59 @@
+apiVersion: dynatrace.com/v1alpha1
+kind: OneAgent
+metadata:
+  # a descriptive name for this object.
+  # all created child objects will be based on it.
+  name: oneagent
+  labels:
+    app: {{ template "dynatrace-oneagent.name" . }}
+    chart: {{ template "dynatrace-oneagent.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  # dynatrace api url including `/api` path at the end
+  apiUrl: {{ .Values.operator.apiUrl }}
+  # disable certificate validation checks for installer download and API communication
+  skipCertCheck: {{ .Values.operator.skipCertCheck }}
+  # name of secret holding `apiToken` and `paasToken`
+  # if unset, name of custom resource is used
+  tokens: {{ template "dynatrace-oneagent.fullname" . }}-tokens
+  # node selector to control the selection of nodes (optional)
+  {{- if .Values.operator.nodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.operator.nodeSelector | indent 4 }}
+  {{- end }}
+  # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ (optional)
+  {{- if .Values.operator.tolerations }}
+  tolerations:
+{{ toYaml .Values.operator.tolerations | indent 4 }}
+  {{- end }}
+  # oneagent installer image (optional)
+  # certified image from Red Hat Container Catalog for use on OpenShift: registry.connect.redhat.com/dynatrace/oneagent
+  # defaults to docker.io/dynatrace/oneagent
+  image: {{ .Values.operator.image }}
+  # arguments to oneagent installer (optional)
+  # https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
+  args:
+  {{- range $key, $value := .Values.operator.args }}
+    {{- if $value }}
+    - --{{ $key }}={{ $value }}
+    {{- else }}
+    - --{{ $key }}
+    {{- end }}
+  {{- end }}
+  # environment variables for oneagent (optional)
+  env:
+  {{- range $name, $value := .Values.operator.env }}
+    - name: {{ $name }}
+      value: {{ quote $value }}
+  {{- end }}
+  # resource settings for oneagent pods (optional)
+  # consumption of oneagent heavily depends on the workload to monitor
+  # please adjust values accordingly
+  #resources:
+  #  requests:
+  #    cpu: 100m
+  #    memory: 512Mi
+  #  limits:
+  #    cpu: 300m
+  #    memory: 1.5Gi

--- a/deploy/helm-chart/templates/role-binding.yaml
+++ b/deploy/helm-chart/templates/role-binding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: dynatrace-oneagent-operator
+  labels:
+    dynatrace: operator
+    operator: oneagent
+    app: {{ template "dynatrace-oneagent.name" . }}
+    chart: {{ template "dynatrace-oneagent.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: dynatrace-oneagent-operator
+roleRef:
+  kind: Role
+  name: dynatrace-oneagent-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm-chart/templates/role.yaml
+++ b/deploy/helm-chart/templates/role.yaml
@@ -1,0 +1,55 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: dynatrace-oneagent-operator
+  labels:
+    dynatrace: operator
+    operator: oneagent
+    app: {{ template "dynatrace-oneagent.name" . }}
+    chart: {{ template "dynatrace-oneagent.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - dynatrace.com
+  resources:
+  - oneagents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "" # "" indicates the core API group
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - "" # "" indicates the core API group
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dynatrace.com
+  resources:
+  - oneagents/finalizers
+  verbs:
+  - update

--- a/deploy/helm-chart/templates/secret.yaml
+++ b/deploy/helm-chart/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and (or .Values.apiToken .Values.paasToken) (not (and .Values.apiToken .Values.paasToken)) -}}
+{{ fail "Dynatrace: apiToken and paasToken are both required values." }}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "dynatrace-oneagent.fullname" . }}-tokens
+  labels:
+    app: {{ template "dynatrace-oneagent.name" . }}
+    chart: {{ template "dynatrace-oneagent.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  apiToken: {{ .Values.apiToken | b64enc | quote }}
+  paasToken: {{ .Values.paasToken | b64enc | quote }}
+type: Opaque

--- a/deploy/helm-chart/templates/service-account-operator.yaml
+++ b/deploy/helm-chart/templates/service-account-operator.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-oneagent-operator
+  labels:
+    app: {{ template "dynatrace-oneagent.name" . }}
+    chart: {{ template "dynatrace-oneagent.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/deploy/helm-chart/templates/service-account.yaml
+++ b/deploy/helm-chart/templates/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-oneagent
+  labels:
+    app: {{ template "dynatrace-oneagent.name" . }}
+    chart: {{ template "dynatrace-oneagent.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -1,0 +1,23 @@
+apiToken:
+paasToken:
+operator:
+  apiUrl:
+  skipCertCheck: false
+  nodeSelector: {}
+  tolerations: []
+  image: docker.io/dynatrace/oneagent
+  args:
+    appLogContentAccess: 1
+    server:
+    tenant:
+    tenantToken:
+    proxy:
+    installPath:
+    infraOnly:
+    user:
+    group:
+    nonRootMode:
+    disableRootFallback:
+    preserveSELinux: false
+    noSELinuxPolicy: false
+  env: {}


### PR DESCRIPTION
Installing this to Kubernetes is much easier with a helm chart.  Thought I would share it back to the community.

Installing with a custom values file:
```sh
helm install -f myvalues.yaml --name dynatrace-oneagent --namespace dynatrace ./deploy/helm-chart
```

Installing with values provided on the CLI:
```sh
helm install --set apiToken=API_TOKEN,paasToken=PAAS_TOKEN,operator.apiUrl=API_URL --name dynatrace-oneagent --namespace dynatrace ./deploy/helm-chart
```

```sh
helm delete dynatrace-oneagent
kubectl delete crd oneagents.dynatrace.com --namespace dynatrace
```