### PR TITLE
Consider SkipCertCheck option in HTTP client

### DIFF
--- a/pkg/runtime/oneagent.go
+++ b/pkg/runtime/oneagent.go
@@ -77,7 +77,7 @@ func Reconcile(oneagent *api.OneAgent) error {
 	}
 
 	// initialize dynatrace client
-	dtc, err := dtclient.NewClient(oneagent.Spec.ApiUrl, apiToken, paasToken)
+	dtc, err := dtclient.NewClient(oneagent.Spec.ApiUrl, apiToken, paasToken, dtclient.SkipCertificateValidation(oneagent.Spec.SkipCertCheck))
 	if err != nil {
 		logrus.WithFields(logrus.Fields{"oneagent": oneagent.Name, "error": err}).Warning("failed to get dynatrace rest client")
 		return err

--- a/pkg/runtime/oneagent.go
+++ b/pkg/runtime/oneagent.go
@@ -77,7 +77,8 @@ func Reconcile(oneagent *api.OneAgent) error {
 	}
 
 	// initialize dynatrace client
-	dtc, err := dtclient.NewClient(oneagent.Spec.ApiUrl, apiToken, paasToken, dtclient.SkipCertificateValidation(oneagent.Spec.SkipCertCheck))
+	var certificateValidation = dtclient.SkipCertificateValidation(oneagent.Spec.SkipCertCheck)
+	dtc, err := dtclient.NewClient(oneagent.Spec.ApiUrl, apiToken, paasToken, certificateValidation)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{"oneagent": oneagent.Name, "error": err}).Warning("failed to get dynatrace rest client")
 		return err


### PR DESCRIPTION
`.spec.skipCertCheck` was only considered for OneAgent DaemonSets. This rendered the operator unable to communicate with Dynatrace server due to certificate validation issues.