### PR TITLE
Add pod priority support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ spec:
   #  limits:
   #    cpu: 300m
   #    memory: 1.5Gi
+  # priority class to assign to oneagent pods (optional)
+  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  #priorityClassName: PRIORITYCLASS
 ```
 Save the snippet to a file or use [./deploy/cr.yaml](https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/cr.yaml) from this repository and adjust its values accordingly.
 A secret holding tokens for authenticating to the Dynatrace cluster needs to be created upfront.

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -37,3 +37,6 @@ spec:
   #  limits:
   #    cpu: 300m
   #    memory: 1.5Gi
+  # priority class to assign to oneagent pods (optional)
+  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  #priorityClassName: PRIORITYCLASS

--- a/pkg/apis/dynatrace/v1alpha1/types.go
+++ b/pkg/apis/dynatrace/v1alpha1/types.go
@@ -40,6 +40,9 @@ type OneAgentSpec struct {
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// Compute Resources required by OneAgent containers.
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// If specified, indicates the pod's priority. Name must be defined by creating a PriorityClass object with that
+	// name. If not specified the setting will be removed from the DaemonSet.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 type OneAgentStatus struct {
 	Version          string                      `json:"version,omitempty"`

--- a/pkg/runtime/v1alpha1/oneagent.go
+++ b/pkg/runtime/v1alpha1/oneagent.go
@@ -71,6 +71,8 @@ func CopyDaemonSetSpecToOneAgentSpec(ds *appsv1.DaemonSetSpec, cr *api.OneAgentS
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	// PriorityClassName
+	cr.PriorityClassName = ds.Template.Spec.PriorityClassName
 	// Image
 	cr.Image = ""
 	if len(ds.Template.Spec.Containers) == 1 {
@@ -114,6 +116,7 @@ func ApplyOneAgentSettings(ds *appsv1.DaemonSet, cr *api.OneAgent) {
 
 	ds.Spec.Template.Spec.NodeSelector = cr.Spec.NodeSelector
 	ds.Spec.Template.Spec.Tolerations = cr.Spec.Tolerations
+	ds.Spec.Template.Spec.PriorityClassName = cr.Spec.PriorityClassName
 
 	if len(ds.Spec.Template.Spec.Containers) == 0 {
 		ds.Spec.Template.Spec.Containers = []corev1.Container{{}}


### PR DESCRIPTION
This allows configuration of pod priorities for OneAgent pods.

resolves #59 