### PR TITLE
Update minimum requirements for the Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ From here on Dynatrace OneAgent Operator controls the lifecycle and keeps track 
 ## Supported platforms
 
 Dynatrace OneAgent Operator is supported on the following platforms:
-* Kubernetes 1.9+
-* OpenShift Container Platform 3.9+
+* Kubernetes 1.11+
+* OpenShift Container Platform 3.11+
+
+For Kubernetes 1.9+ and OpenShift 3.9+, the Dynatrace Operator v0.2.0 can be used.
 
 Help topic _How do I deploy Dynatrace OneAgent as a Docker container?_ lists compatible image and OneAgent versions in its [requirements section](https://www.dynatrace.com/support/help/infrastructure/containers/how-do-i-deploy-dynatrace-oneagent-as-docker-container/#requirements).
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ From here on Dynatrace OneAgent Operator controls the lifecycle and keeps track 
 
 ## Supported platforms
 
-Dynatrace OneAgent Operator is supported on the following platforms:
-* Kubernetes 1.11+
-* OpenShift Container Platform 3.11+
+Depending of the version of the Dynatrace OneAgent Operator, it supports the following platforms:
 
-For Kubernetes 1.9+ and OpenShift 3.9+, the Dynatrace Operator v0.2.0 can be used.
+| Dynatrace OneAgent Operator version | Kubernetes | OpenShift Container Platform |
+| ----------------------------------- | ---------- | ---------------------------- |
+| master                              | 1.11+      | 3.11+                        |
+| v0.2.0                              | 1.9+       | 3.9+                         |
 
 Help topic _How do I deploy Dynatrace OneAgent as a Docker container?_ lists compatible image and OneAgent versions in its [requirements section](https://www.dynatrace.com/support/help/infrastructure/containers/how-do-i-deploy-dynatrace-oneagent-as-docker-container/#requirements).
 


### PR DESCRIPTION
The Operator SDK v0.4 requires Kubernetes 1.11+ (hence OCP 3.11+ as well.)

See: https://github.com/operator-framework/operator-sdk/blob/v0.4.x/doc/user-guide.md#prerequisites