### PR TITLE
change readiness probe in pod spec to handle timeout

### DIFF
--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -326,7 +326,6 @@ func newPodSpecForCR(instance *dynatracev1alpha1.OneAgent) corev1.PodSpec {
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
-							"timeout", "-s", "KILL", "-t", "60", // timeout in case grep fails
 							"grep", "oneagentwatchdo", "/proc/*/stat",
 						},
 					},

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -325,11 +325,15 @@ func newPodSpecForCR(instance *dynatracev1alpha1.OneAgent) corev1.PodSpec {
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"ps", "-C", "oneagentwatchdog"},
+						Command: []string{
+							"timeout", "-s", "KILL", "-t", "60", // timeout in case grep fails
+							"grep", "oneagentwatchdo", "/proc/*/stat",
+						},
 					},
 				},
 				InitialDelaySeconds: 30,
 				PeriodSeconds:       30,
+				TimeoutSeconds:      1,
 			},
 			Resources: instance.Spec.Resources,
 			SecurityContext: &corev1.SecurityContext{

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -325,7 +325,7 @@ func newPodSpecForCR(instance *dynatracev1alpha1.OneAgent) corev1.PodSpec {
 			ReadinessProbe: &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"pgrep", "-f", "oneagentwatchdog"},
+						Command: []string{"ps", "-C", "oneagentwatchdog"},
 					},
 				},
 				InitialDelaySeconds: 30,

--- a/pkg/controller/oneagent/util_test.go
+++ b/pkg/controller/oneagent/util_test.go
@@ -99,6 +99,7 @@ func TestGetToken(t *testing.T) {
 		assert.Equal(t, token2, "dynatrace_test_token_2")
 	}
 }
+
 func TestHasSpecChanged(t *testing.T) {
 	{
 		ds := newDaemonSetSpec()


### PR DESCRIPTION
Resolves the issue where a client's machine was unresponsive due to `pgrep -f` hogging memory. Changes the K8s readiness probe to use `ps -C` in place of that. 

Difficult to test this locally, or via brute-force.

