### PR TITLE
Fix deploy for master

### DIFF
--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -210,8 +210,6 @@ spec:
     singular: oneagent
   scope: Namespaced
   version: v1alpha1
-  subresources:
-    status: {}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -144,8 +144,6 @@ spec:
     singular: oneagent
   scope: Namespaced
   version: v1alpha1
-  subresources:
-    status: {}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Deployment manifest contains a new `subresources` definition, breaking the deployment.