### PR TITLE
Allow access to oneagents/status resource

### DIFF
--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -141,6 +141,7 @@ rules:
   - dynatrace.com
   resources:
   - oneagents/finalizers
+  - oneagents/status
   verbs:
   - update
 - apiGroups:

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -112,6 +112,7 @@ rules:
   - dynatrace.com
   resources:
   - oneagents/finalizers
+  - oneagents/status
   verbs:
   - update
 ---


### PR DESCRIPTION
After the changes on #83 we now also need to allow access to the status subresource in the Operator role.