### PR TITLE
Increasing CTA on apiUrl

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: dynatrace
 spec:
   # dynatrace api url including `/api` path at the end
+  # either set ENVIRONMENTID to the proper tenant id or change the apiUrl as a whole, e.q. for Managed
   apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
   # disable certificate validation checks for installer download and API communication
   skipCertCheck: false


### PR DESCRIPTION
Be more verbose about a needed action on defining a proper `apiUrl` by either replacing `ENVIRONMENTID` with the Dynatrace SaaS tenant or completely overriding in case of a Dynatrace Managed environment.