### PR TITLE
Add field for enabling Istio autoconfiguration to the CR

### DIFF
--- a/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
+++ b/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
@@ -33,6 +33,8 @@ type OneAgentSpec struct {
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// If enabled, OneAgent pods won't be restarted automatically in case a new version is available
 	DisableAgentUpdate bool `json:"disableAgentUpdate,omitempty"`
+	// If enabled, Istio on the cluster will be configured automatically to allow access to the Dynatrace environment.
+	EnableIstio bool `json:"enableIstio,omitempty"`
 }
 
 // OneAgentStatus defines the observed state of OneAgent

--- a/pkg/controller/oneagent/istio.go
+++ b/pkg/controller/oneagent/istio.go
@@ -95,7 +95,7 @@ func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(instance *dynatra
 		name := istio.BuildNameForEndpoint(instance.Name, ch.Host, ch.Port)
 
 		if notFound := r.configurationExists(istio.ServiceEntryGVK, instance.Namespace, name); notFound {
-			logger.Info(fmt.Sprintf("creating Istio ServiceEntry: %s", name))
+			logger.Info("creating Istio ServiceEntry", "objectName", name, "host", ch.Host, "port", ch.Port)
 			payload := istio.BuildServiceEntry(name, ch.Host, ch.Port, ch.Protocol)
 			if err := r.reconcileIstioCreateConfiguration(instance, istio.ServiceEntryGVK, payload); err != nil {
 				logger.Info(fmt.Sprintf("failed to create Istio ServiceEntry: %v", err))
@@ -103,7 +103,7 @@ func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(instance *dynatra
 		}
 
 		if notFound := r.configurationExists(istio.VirtualServiceGVK, instance.Namespace, name); notFound {
-			logger.Info(fmt.Sprintf("creating Istio VirtualService: %s", name))
+			logger.Info("creating Istio VirtualService", "objectName", name, "host", ch.Host, "port", ch.Port, "protocol", ch.Protocol)
 			payload := istio.BuildVirtualService(name, ch.Host, ch.Port, ch.Protocol)
 			if err := r.reconcileIstioCreateConfiguration(instance, istio.VirtualServiceGVK, payload); err != nil {
 				logger.Info(fmt.Sprintf("failed to create Istio VirtualService: %v", err))

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -154,9 +154,11 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 		return reconcile.Result{}, err
 	}
 
-	err = r.reconcileIstio(reqLogger, instance, dtc)
-	if err != nil {
-		reqLogger.Info(fmt.Sprintf("failed to reconcile istio: %v", err))
+	if instance.Spec.EnableIstio {
+		err = r.reconcileIstio(reqLogger, instance, dtc)
+		if err != nil {
+			reqLogger.Info(fmt.Sprintf("failed to reconcile istio: %v", err))
+		}
 	}
 
 	updateCR, err = r.reconcileVersion(reqLogger, instance, dtc)


### PR DESCRIPTION
This adds a new CR field `enableIstio` to enable Istio autoconfiguration. It's off by default.