### PR TITLE
Generate Istio objects for the API URL

### DIFF
--- a/pkg/controller/oneagent/istio.go
+++ b/pkg/controller/oneagent/istio.go
@@ -17,45 +17,75 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *ReconcileOneAgent) reconcileIstio(logger logr.Logger, instance *dynatracev1alpha1.OneAgent, dtc dtclient.Client) error {
+func (r *ReconcileOneAgent) reconcileIstio(logger logr.Logger, instance *dynatracev1alpha1.OneAgent, dtc dtclient.Client) (updated bool, ok bool) {
 	var err error
 
 	// Determine if cluster runs istio in default cluster
 	enabled, err := istio.CheckIstioEnabled(r.config)
 	if err != nil {
-		logger.Error(err, "error while checking for Istio availability")
-		return err
+		logger.Error(err, "istio: failed to verify Istio availability")
+		return false, false
 	}
 
-	logger.Info("Istio status", "enabled", enabled)
+	logger.Info("istio: status", "enabled", enabled)
 
 	if !enabled {
-		return nil
+		return false, true
+	}
+
+	apiHost, err := dtc.GetAPIURLHost()
+	if err != nil {
+		logger.Error(err, "istio: failed to get host for API URL")
+		return false, false
+	}
+
+	if upd, err := r.reconcileIstioConfigurations(logger, instance, []dtclient.CommunicationHost{apiHost}, "api-url"); err != nil {
+		logger.Error(err, "istio: error reconciling config for API URL")
+		return false, false
+	} else if upd {
+		return true, true
 	}
 
 	// Fetch endpoints via Dynatrace client
 	comHosts, err := dtc.GetCommunicationHosts()
 	if err != nil {
-		return err
+		logger.Error(err, "istio: failed to get communication endpoints")
+		return false, false
 	}
 
-	err = r.reconcileIstioCreateConfigurations(instance, comHosts, logger)
+	if upd, err := r.reconcileIstioConfigurations(logger, instance, comHosts, "communication-endpoint"); err != nil {
+		logger.Error(err, "istio: error reconciling config for communication endpoints")
+		return false, false
+	} else if upd {
+		return true, true
+	}
+
+	return false, true
+}
+
+func (r *ReconcileOneAgent) reconcileIstioConfigurations(logger logr.Logger, instance *dynatracev1alpha1.OneAgent,
+	comHosts []dtclient.CommunicationHost, role string) (bool, error) {
+	add, err := r.reconcileIstioCreateConfigurations(instance, comHosts, role, logger)
 	if err != nil {
-		logger.Error(err, "error reconciling Istio config")
-		return err
+		logger.Error(err, "istio: failed to create objects")
+		return false, err
 	}
 
-	r.reconcileIstioRemoveConfigurations(instance, comHosts, logger)
+	rem, err := r.reconcileIstioRemoveConfigurations(instance, comHosts, role, logger)
+	if err != nil {
+		logger.Error(err, "istio: failed to delete objects")
+		return false, err
+	}
 
-	return nil
+	return add || rem, nil
 }
 
 func (r *ReconcileOneAgent) reconcileIstioRemoveConfigurations(instance *dynatracev1alpha1.OneAgent,
-	comHosts []dtclient.CommunicationHost, logger logr.Logger) {
+	comHosts []dtclient.CommunicationHost, role string, logger logr.Logger) (bool, error) {
 
 	listOps := &client.ListOptions{
 		Namespace:     instance.Namespace,
-		LabelSelector: labels.SelectorFromSet(buildLabels(instance.Name)),
+		LabelSelector: labels.SelectorFromSet(buildIstioLabels(instance.Name, role)),
 	}
 
 	seen := map[string]bool{}
@@ -63,33 +93,48 @@ func (r *ReconcileOneAgent) reconcileIstioRemoveConfigurations(instance *dynatra
 		seen[istio.BuildNameForEndpoint(instance.Name, ch.Host, ch.Port)] = true
 	}
 
-	r.reconcileIstioRemoveConfiguration(instance, istio.VirtualServiceGVK, listOps, seen, logger)
-	r.reconcileIstioRemoveConfiguration(instance, istio.ServiceEntryGVK, listOps, seen, logger)
+	vsUpd, err := r.reconcileIstioRemoveConfiguration(instance, istio.VirtualServiceGVK, listOps, seen, logger)
+	if err != nil {
+		return false, err
+	}
+
+	seUpd, err := r.reconcileIstioRemoveConfiguration(instance, istio.ServiceEntryGVK, listOps, seen, logger)
+	if err != nil {
+		return false, err
+	}
+
+	return vsUpd || seUpd, nil
 }
 
 func (r *ReconcileOneAgent) reconcileIstioRemoveConfiguration(instance *dynatracev1alpha1.OneAgent, gvk schema.GroupVersionKind,
-	listOps *client.ListOptions, seen map[string]bool, logger logr.Logger) {
+	listOps *client.ListOptions, seen map[string]bool, logger logr.Logger) (bool, error) {
 
 	var list unstructured.UnstructuredList
 	list.SetGroupVersionKind(gvk)
 
 	if err := r.client.List(context.TODO(), listOps, &list); err != nil {
-		return
+		return false, err
 	}
+
+	upd := false
 
 	for _, item := range list.Items {
 		if _, ok := seen[item.GetName()]; !ok {
+			upd = true
 			logger.Info(fmt.Sprintf("removing Istio %s: %v", gvk.Kind, item.GetName()))
 			if err := r.client.Delete(context.TODO(), &item); err != nil {
-				logger.Info(fmt.Sprintf("failed to delete Istio %s: %v", gvk.Kind, err))
-				continue
+				return false, fmt.Errorf("failed to delete Istio %s: %v", gvk.Kind, err)
 			}
 		}
 	}
+
+	return upd, nil
 }
 
 func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(instance *dynatracev1alpha1.OneAgent,
-	comHosts []dtclient.CommunicationHost, logger logr.Logger) error {
+	comHosts []dtclient.CommunicationHost, role string, logger logr.Logger) (bool, error) {
+
+	upd := false
 
 	for _, ch := range comHosts {
 		name := istio.BuildNameForEndpoint(instance.Name, ch.Host, ch.Port)
@@ -97,25 +142,27 @@ func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(instance *dynatra
 		if notFound := r.configurationExists(istio.ServiceEntryGVK, instance.Namespace, name); notFound {
 			logger.Info("creating Istio ServiceEntry", "objectName", name, "host", ch.Host, "port", ch.Port)
 			payload := istio.BuildServiceEntry(name, ch.Host, ch.Port, ch.Protocol)
-			if err := r.reconcileIstioCreateConfiguration(instance, istio.ServiceEntryGVK, payload); err != nil {
-				logger.Info(fmt.Sprintf("failed to create Istio ServiceEntry: %v", err))
+			if err := r.reconcileIstioCreateConfiguration(instance, istio.ServiceEntryGVK, role, payload); err != nil {
+				return false, fmt.Errorf("failed to create Istio ServiceEntry: %v", err)
 			}
+			upd = true
 		}
 
 		if notFound := r.configurationExists(istio.VirtualServiceGVK, instance.Namespace, name); notFound {
 			logger.Info("creating Istio VirtualService", "objectName", name, "host", ch.Host, "port", ch.Port, "protocol", ch.Protocol)
 			payload := istio.BuildVirtualService(name, ch.Host, ch.Port, ch.Protocol)
-			if err := r.reconcileIstioCreateConfiguration(instance, istio.VirtualServiceGVK, payload); err != nil {
-				logger.Info(fmt.Sprintf("failed to create Istio VirtualService: %v", err))
+			if err := r.reconcileIstioCreateConfiguration(instance, istio.VirtualServiceGVK, role, payload); err != nil {
+				return false, fmt.Errorf("failed to create Istio VirtualService: %v", err)
 			}
+			upd = true
 		}
 	}
 
-	return nil
+	return upd, nil
 }
 
 func (r *ReconcileOneAgent) reconcileIstioCreateConfiguration(instance *dynatracev1alpha1.OneAgent,
-	gvk schema.GroupVersionKind, payload []byte) error {
+	gvk schema.GroupVersionKind, role string, payload []byte) error {
 
 	var obj unstructured.Unstructured
 	obj.Object = make(map[string]interface{})
@@ -125,7 +172,7 @@ func (r *ReconcileOneAgent) reconcileIstioCreateConfiguration(instance *dynatrac
 	}
 
 	obj.SetGroupVersionKind(gvk)
-	obj.SetLabels(buildLabels(instance.Name))
+	obj.SetLabels(buildIstioLabels(instance.Name, role))
 
 	if err := controllerutil.SetControllerReference(instance, &obj, r.scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference: %v", err)
@@ -146,4 +193,10 @@ func (r *ReconcileOneAgent) configurationExists(gvk schema.GroupVersionKind, nam
 	key := client.ObjectKey{Namespace: namespace, Name: name}
 
 	return errors.IsNotFound(r.client.Get(context.TODO(), key, &objQuery))
+}
+
+func buildIstioLabels(name, role string) map[string]string {
+	labels := buildLabels(name)
+	labels["dynatrace-istio-role"] = role
+	return labels
 }

--- a/pkg/controller/oneagent/util_test.go
+++ b/pkg/controller/oneagent/util_test.go
@@ -36,6 +36,11 @@ func (o *MyDynatraceClient) GetCommunicationHosts() ([]dtclient.CommunicationHos
 	return args.Get(0).([]dtclient.CommunicationHost), args.Error(1)
 }
 
+func (o *MyDynatraceClient) GetAPIURLHost() (dtclient.CommunicationHost, error) {
+	args := o.Called()
+	return args.Get(0).(dtclient.CommunicationHost), args.Error(1)
+}
+
 func TestBuildLabels(t *testing.T) {
 	l := buildLabels("my-name")
 	assert.Equal(t, l["dynatrace"], "oneagent")

--- a/pkg/dynatrace-client/client.go
+++ b/pkg/dynatrace-client/client.go
@@ -49,7 +49,7 @@ type Client interface {
 	// Returns an error if there was also an error response from the server.
 	GetCommunicationHosts() ([]CommunicationHost, error)
 
-	// GetCommunicationHosts returns a CommunicationHost for the client's API URL. Or error, if failed to be parsed.
+	// GetAPIURLHost returns a CommunicationHost for the client's API URL. Or error, if failed to be parsed.
 	GetAPIURLHost() (CommunicationHost, error)
 }
 

--- a/pkg/dynatrace-client/client_test.go
+++ b/pkg/dynatrace-client/client_test.go
@@ -260,3 +260,67 @@ func TestReadCommunicationHosts(t *testing.T) {
 		assert.Error(t, err, "no hosts available")
 	}
 }
+
+func TestCommunicationHostParsing(t *testing.T) {
+	var err error
+	var ch CommunicationHost
+
+	// Successful parsing
+
+	ch, err = parseEndpoint("https://example.live.dynatrace.com/communication")
+	assert.NoError(t, err)
+	assert.Equal(t, CommunicationHost{
+		Protocol: "https",
+		Host:     "example.live.dynatrace.com",
+		Port:     443,
+	}, ch)
+
+	ch, err = parseEndpoint("https://managedhost.com:9999/here/communication")
+	assert.NoError(t, err)
+	assert.Equal(t, CommunicationHost{
+		Protocol: "https",
+		Host:     "managedhost.com",
+		Port:     9999,
+	}, ch)
+
+	ch, err = parseEndpoint("https://example.live.dynatrace.com/communication")
+	assert.NoError(t, err)
+	assert.Equal(t, CommunicationHost{
+		Protocol: "https",
+		Host:     "example.live.dynatrace.com",
+		Port:     443,
+	}, ch)
+
+	ch, err = parseEndpoint("https://10.0.0.1:8000/communication")
+	assert.NoError(t, err)
+	assert.Equal(t, CommunicationHost{
+		Protocol: "https",
+		Host:     "10.0.0.1",
+		Port:     8000,
+	}, ch)
+
+	ch, err = parseEndpoint("http://insecurehost/communication")
+	assert.NoError(t, err)
+	assert.Equal(t, CommunicationHost{
+		Protocol: "http",
+		Host:     "insecurehost",
+		Port:     80,
+	}, ch)
+
+	// Failures
+
+	_, err = parseEndpoint("https://managedhost.com:notaport/here/communication")
+	assert.Error(t, err)
+
+	_, err = parseEndpoint("example.live.dynatrace.com:80/communication")
+	assert.Error(t, err)
+
+	_, err = parseEndpoint("ftp://randomhost.com:80/communication")
+	assert.Error(t, err)
+
+	_, err = parseEndpoint("unix:///some/local/file")
+	assert.Error(t, err)
+
+	_, err = parseEndpoint("shouldnotbeparsed")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
On this PR we're now creating VirtualService and ServiceEntry objects for the API URL so that the Operator can access.

If Istio autoconfiguration is enabled, this happens before rolling the agent pods.

Also included, changing Istio log entries to have "istio:" prefix in an attempt to simplify the entries.