### PR TITLE
Use Kubebuilder and envtest.Environment to test the reconciler operations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
       # Run tests and build the binaries.
       - run:
           name: Run tests
+          command: go test -cover -v $(go list ./... | circleci tests split)
+      - run:
+          name: Run integration tests
           command: go test -cover -tags integration -v $(go list ./... | circleci tests split)
       - run:
           name: Build binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       # Run tests and build the binaries.
       - run:
           name: Run tests
-          command: go test -cover -v $(go list ./... | circleci tests split)
+          command: go test -cover -tags integration -v $(go list ./... | circleci tests split)
       - run:
           name: Build binary
           command: go build -o ./build/_output/bin/dynatrace-oneagent-operator ./cmd/manager

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,30 @@ jobs:
     parallelism: 4
     steps:
       - checkout
+
+      # Download and cache Kubebuilder.
+      - run:
+          name: Prepare directories for Kubebuilder
+          command: |
+            sudo mkdir -p /usr/local/kubebuilder
+            sudo chmod 777 /usr/local/kubebuilder
+      - restore_cache:
+          key: kubebuilder-1.0.8
+          paths:
+              - /usr/local/kubebuilder/bin
+      - run:
+          name: Fetch Kubebuilder
+          command: |
+            if [ ! -d "/usr/local/kubebuilder/bin" ]; then
+              curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.8/kubebuilder_1.0.8_linux_amd64.tar.gz -o kubebuilder.tar.gz
+              tar -zxvf kubebuilder.tar.gz --strip-components=1 -C /usr/local/kubebuilder
+            fi
+      - save_cache:
+          key: kubebuilder-1.0.8
+          paths:
+              - /usr/local/kubebuilder/bin
+
+      # Download an cache dependencies.
       - restore_cache:
           key: gopkg-{{ checksum "Gopkg.toml" }}
           paths:
@@ -33,6 +57,8 @@ jobs:
           paths:
               - /go/src/github.com/Dynatrace/dynatrace-oneagent-operator/vendor
               - /go/pkg
+
+      # Run tests and build the binaries.
       - run:
           name: Run tests
           command: go test -cover -v $(go list ./... | circleci tests split)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -212,6 +212,20 @@
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:76efa3b55850d9caa14f8c0b3a951797f9bc2ffc283526073dcad1b06b6e02d3"
+  name = "github.com/hpcloud/tail"
+  packages = [
+    ".",
+    "ratelimiter",
+    "util",
+    "watch",
+    "winfile",
+  ]
+  pruneopts = "NT"
+  revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:aaa38889f11896ee3644d77e17dc7764cc47f5f3d3b488268df2af2b52541c5f"
   name = "github.com/imdario/mergo"
   packages = ["."]
@@ -270,6 +284,56 @@
   pruneopts = "NT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
+
+[[projects]]
+  digest = "1:545744762d3d6d59328a38e44f571baaeda30184b88b43a28879bedf7711afa5"
+  name = "github.com/onsi/ginkgo"
+  packages = [
+    ".",
+    "config",
+    "internal/codelocation",
+    "internal/containernode",
+    "internal/failer",
+    "internal/leafnodes",
+    "internal/remote",
+    "internal/spec",
+    "internal/spec_iterator",
+    "internal/specrunner",
+    "internal/suite",
+    "internal/testingtproxy",
+    "internal/writer",
+    "reporters",
+    "reporters/stenographer",
+    "reporters/stenographer/support/go-colorable",
+    "reporters/stenographer/support/go-isatty",
+    "types",
+  ]
+  pruneopts = "NT"
+  revision = "eea6ad008b96acdaa524f5b409513bf062b500ad"
+  version = "v1.8.0"
+
+[[projects]]
+  digest = "1:9f353a779b8b118229dfc1541e41d72d1a3a6f2d13756f5fe66daeb0f52191ab"
+  name = "github.com/onsi/gomega"
+  packages = [
+    ".",
+    "format",
+    "gbytes",
+    "gexec",
+    "internal/assertion",
+    "internal/asyncassertion",
+    "internal/oraclematcher",
+    "internal/testingtsupport",
+    "matchers",
+    "matchers/support/goraph/bipartitegraph",
+    "matchers/support/goraph/edge",
+    "matchers/support/goraph/node",
+    "matchers/support/goraph/util",
+    "types",
+  ]
+  pruneopts = "NT"
+  revision = "90e289841c1ed79b7a598a7cd9959750cb5e89e2"
+  version = "v1.5.0"
 
 [[projects]]
   digest = "1:0b2dd5813eba320fd99869c1a5c4b54eb6950544259f2389c5b137be2168429a"
@@ -434,6 +498,9 @@
   packages = [
     "context",
     "context/ctxhttp",
+    "html",
+    "html/atom",
+    "html/charset",
     "http/httpguts",
     "http2",
     "http2/hpack",
@@ -473,12 +540,24 @@
   packages = [
     "collate",
     "collate/build",
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
     "internal/colltab",
     "internal/gen",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "internal/utf8internal",
     "language",
+    "runes",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
@@ -540,12 +619,29 @@
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
+  name = "gopkg.in/fsnotify.v1"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  source = "https://github.com/fsnotify/fsnotify.git"
+  version = "v1.4.7"
+
+[[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
   pruneopts = "NT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
+
+[[projects]]
+  branch = "v1"
+  digest = "1:8fb1ccb16a6cfecbfdfeb84d8ea1cc7afa8f9ef16526bc2326f72d993e32cef1"
+  name = "gopkg.in/tomb.v1"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
   digest = "1:18108594151654e9e696b27b181b953f9a90b16bf14d253dd1b397b025a1487f"
@@ -604,6 +700,19 @@
   revision = "b503174bad5991eb66f18247f52e41c3258f6348"
 
 [[projects]]
+  digest = "1:82b4765488fd2a8bcefb93e196fdbfe342d33b16ae073a6f51bb4fb13e81e102"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = [
+    "pkg/apis/apiextensions",
+    "pkg/apis/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset",
+    "pkg/client/clientset/clientset/scheme",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
+  ]
+  pruneopts = "NT"
+  revision = "0cd23ebeb6882bd1cdc2cb15fc7b2d72e8a86a5b"
+
+[[projects]]
   digest = "1:868de7cbaa0ecde6dc231c1529a10ae01bb05916095c0c992186e2a5cac57e79"
   name = "k8s.io/apimachinery"
   packages = [
@@ -659,6 +768,7 @@
   name = "k8s.io/client-go"
   packages = [
     "discovery",
+    "discovery/fake",
     "dynamic",
     "kubernetes",
     "kubernetes/scheme",
@@ -803,7 +913,7 @@
   revision = "ced9eb3070a5f1c548ef46e8dfe2a97c208d9f03"
 
 [[projects]]
-  digest = "1:e03ddaf9f31bccbbb8c33eabad2c85025a95ca98905649fd744e0a54c630a064"
+  digest = "1:576aa0abec4807e7a87b3d235c6e1b4a8dde240c7dcaa0f5a14429c59afd71a8"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -811,9 +921,10 @@
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
-    "pkg/client/fake",
     "pkg/controller",
     "pkg/controller/controllerutil",
+    "pkg/envtest",
+    "pkg/envtest/printer",
     "pkg/event",
     "pkg/handler",
     "pkg/internal/controller",
@@ -834,11 +945,24 @@
     "pkg/source/internal",
     "pkg/webhook/admission",
     "pkg/webhook/admission/types",
+    "pkg/webhook/internal/metrics",
     "pkg/webhook/types",
   ]
   pruneopts = "NT"
-  revision = "c63ebda0bf4be5f0a8abd4003e4ea546032545ba"
-  version = "v0.1.8"
+  revision = "f6f0bc9611363b43664d08fb097ab13243ef621d"
+  version = "v0.1.9"
+
+[[projects]]
+  digest = "1:1b357310eaf2f448295aa077aaf077b56170bda56d2425f1d5d097ee4ff1c1ac"
+  name = "sigs.k8s.io/testing_frameworks"
+  packages = [
+    "integration",
+    "integration/addr",
+    "integration/internal",
+  ]
+  pruneopts = "NT"
+  revision = "d348cb12705b516376e0c323bacca72b00a78425"
+  version = "v0.1.1"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -857,6 +981,7 @@
     "istio.io/api/networking/v1alpha3",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
@@ -864,11 +989,18 @@
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/util/flowcontrol",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",
@@ -879,9 +1011,9 @@
     "k8s.io/gengo/args",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
-    "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
+    "sigs.k8s.io/controller-runtime/pkg/envtest",
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,7 +41,11 @@ required = [
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"
-  version = "=v0.1.8"
+  version = "=v0.1.9"
+
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify.git"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,6 +6,16 @@
 OneAgent Operator. The `operator-sdk` tool needs to be installed upfront as outlined in the
 [Operator SDK User Guide](https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#install-the-operator-sdk-cli).
 
+#### Unit tests
+
+The tests can be executed with
+
+```
+$ go test ./...
+```
+
+They also require Kubebuilder, unpack the binaries from [the release package](https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.8/kubebuilder_1.0.8_linux_amd64.tar.gz) in `/usr/local/kubebuilder/bin` where they will be looked at by default.
+
 #### Build and push your image
 Replace `REGISTRY` with your Registry\`s URN:
 ```
@@ -13,7 +23,6 @@ $ cd $GOPATH/src/github.com/Dynatrace/dynatrace-oneagent-operator
 $ operator-sdk build REGISTRY/dynatrace-oneagent-operator
 $ docker push REGISTRY/dynatrace-oneagent-operator
 ```
-
 
 #### Deploy operator
 Change the `image` field in `./deploy/operator.yaml` to the URN of your image.

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,15 +6,21 @@
 OneAgent Operator. The `operator-sdk` tool needs to be installed upfront as outlined in the
 [Operator SDK User Guide](https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#install-the-operator-sdk-cli).
 
-#### Unit tests
+#### Tests
 
-The tests can be executed with
+The unit tests can be executed with
 
 ```
 $ go test ./...
 ```
 
-They also require Kubebuilder, unpack the binaries from [the release package](https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.8/kubebuilder_1.0.8_linux_amd64.tar.gz) in `/usr/local/kubebuilder/bin` where they will be looked at by default.
+And integration tests,
+
+```
+$ go test -tags integration ./...
+```
+
+These integration tests also require Kubebuilder, unpack the binaries from [the release package](https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.8/kubebuilder_1.0.8_linux_amd64.tar.gz) in `/usr/local/kubebuilder/bin` where they will be looked at by default.
 
 #### Build and push your image
 Replace `REGISTRY` with your Registry\`s URN:

--- a/pkg/controller/oneagent/envutils_test.go
+++ b/pkg/controller/oneagent/envutils_test.go
@@ -138,8 +138,8 @@ func newTestEnvironment() (*ControllerTestEnvironment, error) {
 		server: svr,
 		Client: c,
 		CommunicationHosts: []string{
-			"https://endpoint1.dev.ruxitlabs.com/communication",
-			"https://endpoint2.dev.ruxitlabs.com/communication",
+			"https://endpoint1.test.com/communication",
+			"https://endpoint2.test.com/communication",
 		},
 		Reconciler: &ReconcileOneAgent{
 			client: c,

--- a/pkg/controller/oneagent/envutils_test.go
+++ b/pkg/controller/oneagent/envutils_test.go
@@ -1,0 +1,199 @@
+package oneagent
+
+// This file includes utilities to start an environment with API Server, and a configured reconciler.
+
+import (
+	"context"
+	"os"
+
+	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis"
+	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
+	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+const (
+	DefaultTestAPIURL    = "https://ENVIRONMENTID.live.dynatrace.com/api"
+	DefaultTestNamespace = "dynatrace"
+)
+
+var testEnvironmentCRDs = []*apiextensionsv1beta1.CustomResourceDefinition{
+	&apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "oneagents.dynatrace.com",
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "dynatrace.com",
+			Version: "v1alpha1",
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Kind:     "OneAgent",
+				ListKind: "OneAgentList",
+				Plural:   "oneagents",
+				Singular: "oneagent",
+			},
+			Scope: apiextensionsv1beta1.NamespaceScoped,
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
+		},
+	},
+	&apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "virtualservices.networking.istio.io",
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "networking.istio.io",
+			Version: "v1alpha3",
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Kind:     "VirtualService",
+				ListKind: "VirtualServiceList",
+				Plural:   "virtualservices",
+				Singular: "virtualservice",
+			},
+			Scope: apiextensionsv1beta1.NamespaceScoped,
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
+		},
+	},
+	&apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "serviceentries.networking.istio.io",
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "networking.istio.io",
+			Version: "v1alpha3",
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Kind:     "ServiceEntry",
+				ListKind: "ServiceEntryList",
+				Plural:   "serviceentries",
+				Singular: "serviceentry",
+			},
+			Scope: apiextensionsv1beta1.NamespaceScoped,
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
+		},
+	},
+}
+
+func init() {
+	// Register OneAgent and Istio object schemas.
+	apis.AddToScheme(scheme.Scheme)
+}
+
+type ControllerTestEnvironment struct {
+	CommunicationHosts []string
+	Client             client.Client
+	Reconciler         *ReconcileOneAgent
+
+	server *envtest.Environment
+}
+
+func newTestEnvironment() (*ControllerTestEnvironment, error) {
+	svr := &envtest.Environment{
+		KubeAPIServerFlags: append(envtest.DefaultKubeAPIServerFlags, "--allow-privileged"),
+		CRDs:               testEnvironmentCRDs,
+	}
+
+	// TODO: we shouldn't need to set environment variables. Remove usages from our code.
+	os.Setenv(k8sutil.WatchNamespaceEnvVar, "dynatrace")
+
+	cfg, err := svr.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		svr.Stop()
+		return nil, err
+	}
+
+	if err = c.Create(context.TODO(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "token-test",
+			Namespace: DefaultTestNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"paasToken": []byte("42"),
+			"apiToken":  []byte("43"),
+		},
+	}); err != nil {
+		svr.Stop()
+		return nil, err
+	}
+
+	e := &ControllerTestEnvironment{
+		server: svr,
+		Client: c,
+		CommunicationHosts: []string{
+			"https://endpoint1.dev.ruxitlabs.com/communication",
+			"https://endpoint2.dev.ruxitlabs.com/communication",
+		},
+		Reconciler: &ReconcileOneAgent{
+			client: c,
+			scheme: scheme.Scheme,
+			config: cfg,
+			logger: logf.ZapLoggerTo(os.Stdout, true),
+		},
+	}
+
+	e.Reconciler.dynatraceClientFunc = e.mockDynatraceClient
+
+	return e, nil
+}
+
+func (e *ControllerTestEnvironment) Stop() error {
+	return e.server.Stop()
+}
+
+func (e *ControllerTestEnvironment) AddOneAgent(n string, s *dynatracev1alpha1.OneAgentSpec) error {
+	dynatracev1alpha1.SetDefaults_OneAgentSpec(s)
+
+	return e.Client.Create(context.TODO(), &dynatracev1alpha1.OneAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n,
+			Namespace: DefaultTestNamespace,
+		},
+		Spec: *s,
+	})
+}
+
+func (e *ControllerTestEnvironment) mockDynatraceClient(oa *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
+	commHosts := make([]dtclient.CommunicationHost, len(e.CommunicationHosts))
+
+	for i, c := range e.CommunicationHosts {
+		commHosts[i] = dtclient.CommunicationHost{Protocol: "https", Host: c, Port: 443}
+	}
+
+	dtc := new(MyDynatraceClient)
+	dtc.On("GetVersionForIp", "127.0.0.1").Return("1.2.3", nil)
+	dtc.On("GetCommunicationHosts").Return(commHosts, nil)
+	dtc.On("GetAPIURLHost").Return(dtclient.CommunicationHost{
+		Protocol: "https",
+		Host:     DefaultTestAPIURL,
+		Port:     443,
+	}, nil)
+
+	return dtc, nil
+}
+
+func newReconciliationRequest(oaName string) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      oaName,
+			Namespace: DefaultTestNamespace,
+		},
+	}
+}

--- a/pkg/controller/oneagent/istio.go
+++ b/pkg/controller/oneagent/istio.go
@@ -142,8 +142,8 @@ func (r *ReconcileOneAgent) removeIstioConfigurationForServiceEntry(
 				logger.Error(err, fmt.Sprintf("istio: error deleteing service entry, %s : %v", se.GetName(), err))
 				continue
 			}
+			del = true
 		}
-		del = true
 	}
 	return del
 
@@ -175,8 +175,8 @@ func (r *ReconcileOneAgent) removeIstioConfigurationForVirtualService(
 				logger.Error(err, fmt.Sprintf("istio: error deleteing virtual service, %s : %v", vs.GetName(), err))
 				continue
 			}
+			del = true
 		}
-		del = true
 	}
 	return del
 }

--- a/pkg/controller/oneagent/istio_test.go
+++ b/pkg/controller/oneagent/istio_test.go
@@ -2,20 +2,16 @@ package oneagent
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"os"
 	"testing"
 
 	_ "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis"
-	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	fakeistio "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/networking/clientset/versioned/fake"
 	istiov1alpha3 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/networking/istio/v1alpha3"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/istio"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestIstioClient_CreateIstioObjects(t *testing.T) {
@@ -55,130 +51,4 @@ func TestIstioClient_BuildDynatraceVirtualService(t *testing.T) {
 		t.Error("Expected items, got nil")
 	}
 	t.Logf("list of istio object %v", vsList.Items)
-}
-
-func TestReconcileOneAgent_ReconcileIstio(t *testing.T) {
-	e, err := newTestEnvironment()
-	assert.NoError(t, err, "failed to start test environment")
-
-	defer e.Stop()
-
-	e.AddOneAgent("oneagent", &dynatracev1alpha1.OneAgentSpec{
-		ApiUrl:      DefaultTestAPIURL,
-		Tokens:      "token-test",
-		EnableIstio: true,
-	})
-
-	req := newReconciliationRequest("oneagent")
-
-	// For the first reconciliation, we only create Istio objects for the API URL.
-	_, err = e.Reconciler.Reconcile(req)
-	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 1, 1)
-
-	// Once the API URL is open, we create Istio objects for each communication endpoint.
-	_, err = e.Reconciler.Reconcile(req)
-	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 3, 3)
-
-	// Add a new communication endpoint.
-	e.CommunicationHosts = append(e.CommunicationHosts, "https://endpoint3.dev.ruxitlabs.com/communication")
-	_, err = e.Reconciler.Reconcile(req)
-	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 4, 4)
-
-	// Remove two communication endpoints.
-	e.CommunicationHosts = e.CommunicationHosts[2:]
-	_, err = e.Reconciler.Reconcile(req)
-	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 2, 2)
-}
-
-func TestReconcileOneAgent_ReconcileIstioWithMultipleOneAgentObjects(t *testing.T) {
-	e, err := newTestEnvironment()
-	assert.NoError(t, err, "failed to start test environment")
-
-	defer e.Stop()
-
-	e.AddOneAgent("oneagent1", &dynatracev1alpha1.OneAgentSpec{
-		ApiUrl:      DefaultTestAPIURL,
-		Tokens:      "token-test",
-		EnableIstio: true,
-	})
-
-	e.AddOneAgent("oneagent2", &dynatracev1alpha1.OneAgentSpec{
-		ApiUrl:      DefaultTestAPIURL,
-		Tokens:      "token-test",
-		EnableIstio: true,
-	})
-
-	req1 := newReconciliationRequest("oneagent1")
-	req2 := newReconciliationRequest("oneagent2")
-
-	// Operations on the CommunicationHosts list applies to both OneAgent objects, but that is fine, since that
-	// is the most common use case as well, i.e., customers using multiple OneAgent objects for different
-	// environments.
-
-	// For the first reconciliation, we only create Istio objects for the API URL.
-	_, err = e.Reconciler.Reconcile(req1)
-	assert.NoError(t, err, "failed to reconcile")
-	_, err = e.Reconciler.Reconcile(req2)
-	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 2, 2)
-
-	// Once the API URL is open, we create Istio objects for each communication endpoint.
-	_, err = e.Reconciler.Reconcile(req1)
-	assert.NoError(t, err, "failed to reconcile")
-	_, err = e.Reconciler.Reconcile(req2)
-	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 6, 6)
-
-	// Add a new communication endpoint.
-	e.CommunicationHosts = append(e.CommunicationHosts, "https://endpoint3.dev.ruxitlabs.com/communication")
-	_, err = e.Reconciler.Reconcile(req1)
-	assert.NoError(t, err, "failed to reconcile")
-	_, err = e.Reconciler.Reconcile(req2)
-	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 8, 8)
-
-	// Remove two communication endpoints.
-	e.CommunicationHosts = e.CommunicationHosts[2:]
-	_, err = e.Reconciler.Reconcile(req1)
-	assert.NoError(t, err, "failed to reconcile")
-	_, err = e.Reconciler.Reconcile(req2)
-	assert.NoError(t, err, "failed to reconcile")
-	assertIstioObjects(t, e.Client, 4, 4)
-}
-
-// assertIstioObjects confirms that we have the expected number of ServiceEntry and VirtualService objects, set by ese and evs respectively.
-func assertIstioObjects(t *testing.T, c client.Client, ese, evs int) {
-	var lst []string
-
-	lst = findServiceEntries(t, c)
-	assert.Equal(t, ese, len(lst), "unexpected number of ServiceEntry objects: %v", lst)
-
-	lst = findVirtualServices(t, c)
-	assert.Equal(t, evs, len(lst), "unexpected number of VirtualService objects: %v", lst)
-}
-
-func findServiceEntries(t *testing.T, c client.Client) []string {
-	var lst istiov1alpha3.ServiceEntryList
-	assert.NoError(t, c.List(context.TODO(), &client.ListOptions{}, &lst), "failed to query ServiceEntry objects")
-
-	var out []string
-	for _, x := range lst.Items {
-		out = append(out, x.Spec.Hosts...)
-	}
-	return out
-}
-
-func findVirtualServices(t *testing.T, c client.Client) []string {
-	var lst istiov1alpha3.VirtualServiceList
-	assert.NoError(t, c.List(context.TODO(), &client.ListOptions{}, &lst), "failed to query VirtualService objects")
-
-	var out []string
-	for _, x := range lst.Items {
-		out = append(out, x.Spec.Hosts...)
-	}
-	return out
 }

--- a/pkg/controller/oneagent/isto_integration_test.go
+++ b/pkg/controller/oneagent/isto_integration_test.go
@@ -1,0 +1,140 @@
+// +build integration
+
+package oneagent
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis"
+	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
+	istiov1alpha3 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/networking/istio/v1alpha3"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestReconcileOneAgent_ReconcileIstio(t *testing.T) {
+	e, err := newTestEnvironment()
+	assert.NoError(t, err, "failed to start test environment")
+
+	defer e.Stop()
+
+	e.AddOneAgent("oneagent", &dynatracev1alpha1.OneAgentSpec{
+		ApiUrl:      DefaultTestAPIURL,
+		Tokens:      "token-test",
+		EnableIstio: true,
+	})
+
+	req := newReconciliationRequest("oneagent")
+
+	// For the first reconciliation, we only create Istio objects for the API URL.
+	_, err = e.Reconciler.Reconcile(req)
+	assert.NoError(t, err, "failed to reconcile")
+	assertIstioObjects(t, e.Client, 1, 1)
+
+	// Once the API URL is open, we create Istio objects for each communication endpoint.
+	_, err = e.Reconciler.Reconcile(req)
+	assert.NoError(t, err, "failed to reconcile")
+	assertIstioObjects(t, e.Client, 3, 3)
+
+	// Add a new communication endpoint.
+	e.CommunicationHosts = append(e.CommunicationHosts, "https://endpoint3.test.com/communication")
+	_, err = e.Reconciler.Reconcile(req)
+	assert.NoError(t, err, "failed to reconcile")
+	assertIstioObjects(t, e.Client, 4, 4)
+
+	// Remove two communication endpoints.
+	e.CommunicationHosts = e.CommunicationHosts[2:]
+	_, err = e.Reconciler.Reconcile(req)
+	assert.NoError(t, err, "failed to reconcile")
+	assertIstioObjects(t, e.Client, 2, 2)
+}
+
+func TestReconcileOneAgent_ReconcileIstioWithMultipleOneAgentObjects(t *testing.T) {
+	e, err := newTestEnvironment()
+	assert.NoError(t, err, "failed to start test environment")
+
+	defer e.Stop()
+
+	e.AddOneAgent("oneagent1", &dynatracev1alpha1.OneAgentSpec{
+		ApiUrl:      DefaultTestAPIURL,
+		Tokens:      "token-test",
+		EnableIstio: true,
+	})
+
+	e.AddOneAgent("oneagent2", &dynatracev1alpha1.OneAgentSpec{
+		ApiUrl:      DefaultTestAPIURL,
+		Tokens:      "token-test",
+		EnableIstio: true,
+	})
+
+	req1 := newReconciliationRequest("oneagent1")
+	req2 := newReconciliationRequest("oneagent2")
+
+	// Operations on the CommunicationHosts list applies to both OneAgent objects, but that is fine, since that
+	// is the most common use case as well, i.e., customers using multiple OneAgent objects for different
+	// environments.
+
+	// For the first reconciliation, we only create Istio objects for the API URL.
+	_, err = e.Reconciler.Reconcile(req1)
+	assert.NoError(t, err, "failed to reconcile")
+	_, err = e.Reconciler.Reconcile(req2)
+	assert.NoError(t, err, "failed to reconcile")
+	assertIstioObjects(t, e.Client, 2, 2)
+
+	// Once the API URL is open, we create Istio objects for each communication endpoint.
+	_, err = e.Reconciler.Reconcile(req1)
+	assert.NoError(t, err, "failed to reconcile")
+	_, err = e.Reconciler.Reconcile(req2)
+	assert.NoError(t, err, "failed to reconcile")
+	assertIstioObjects(t, e.Client, 6, 6)
+
+	// Add a new communication endpoint.
+	e.CommunicationHosts = append(e.CommunicationHosts, "https://testendpoint.com/communication")
+	_, err = e.Reconciler.Reconcile(req1)
+	assert.NoError(t, err, "failed to reconcile")
+	_, err = e.Reconciler.Reconcile(req2)
+	assert.NoError(t, err, "failed to reconcile")
+	assertIstioObjects(t, e.Client, 8, 8)
+
+	// Remove two communication endpoints.
+	e.CommunicationHosts = e.CommunicationHosts[2:]
+	_, err = e.Reconciler.Reconcile(req1)
+	assert.NoError(t, err, "failed to reconcile")
+	_, err = e.Reconciler.Reconcile(req2)
+	assert.NoError(t, err, "failed to reconcile")
+	assertIstioObjects(t, e.Client, 4, 4)
+}
+
+// assertIstioObjects confirms that we have the expected number of ServiceEntry and VirtualService objects, set by ese and evs respectively.
+func assertIstioObjects(t *testing.T, c client.Client, ese, evs int) {
+	var lst []string
+
+	lst = findServiceEntries(t, c)
+	assert.Equal(t, ese, len(lst), "unexpected number of ServiceEntry objects: %v", lst)
+
+	lst = findVirtualServices(t, c)
+	assert.Equal(t, evs, len(lst), "unexpected number of VirtualService objects: %v", lst)
+}
+
+func findServiceEntries(t *testing.T, c client.Client) []string {
+	var lst istiov1alpha3.ServiceEntryList
+	assert.NoError(t, c.List(context.TODO(), &client.ListOptions{}, &lst), "failed to query ServiceEntry objects")
+
+	var out []string
+	for _, x := range lst.Items {
+		out = append(out, x.Spec.Hosts...)
+	}
+	return out
+}
+
+func findVirtualServices(t *testing.T, c client.Client) []string {
+	var lst istiov1alpha3.VirtualServiceList
+	assert.NoError(t, c.List(context.TODO(), &client.ListOptions{}, &lst), "failed to query VirtualService objects")
+
+	var out []string
+	for _, x := range lst.Items {
+		out = append(out, x.Spec.Hosts...)
+	}
+	return out
+}

--- a/pkg/controller/oneagent/oneagent_controller_integration_test.go
+++ b/pkg/controller/oneagent/oneagent_controller_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package oneagent
 
 import (

--- a/pkg/controller/oneagent/oneagent_controller_test.go
+++ b/pkg/controller/oneagent/oneagent_controller_test.go
@@ -2,162 +2,36 @@ package oneagent
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"os"
 	"testing"
 
-	api "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
-	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
-	restclient "k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func mockBuildDynatraceClient(instance *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
-
-	commHosts := []dtclient.CommunicationHost{
-		dtclient.CommunicationHost{
-			Protocol: "https",
-			Host:     "https://endpoint1.dev.ruxitlabs.com/communication",
-			Port:     443,
-		},
-		dtclient.CommunicationHost{
-			Protocol: "https",
-			Host:     "https://endpoint2.dev.ruxitlabs.com/communication",
-			Port:     443,
-		},
-	}
-
-	dtc := new(MyDynatraceClient)
-	dtc.On("GetVersionForIp", "127.0.0.1").Return("1.2.3", nil)
-	dtc.On("GetCommunicationHosts").Return(commHosts, nil)
-	dtc.On("GetAPIURLHost").Return(dtclient.CommunicationHost{
-		Protocol: "https",
-		Host:     testAPIUrl,
-		Port:     443,
-	}, nil)
-
-	return dtc, nil
-}
-
-func initMockServer(t *testing.T) *httptest.Server {
-	list := &metav1.APIGroupList{
-		Groups: []metav1.APIGroup{
-			{
-				Name: "networking.istio.io",
-				Versions: []metav1.GroupVersionForDiscovery{
-					{GroupVersion: "v1alpha3", Version: "v1alpha3"},
-					{GroupVersion: "v1alpha3", Version: "v1alpha3"},
-				},
-			},
-		},
-	}
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		var resources interface{}
-		switch req.URL.Path {
-		case "/apis":
-			resources = list
-		default:
-			t.Logf("unexpected request: %s", req.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		output, err := json.Marshal(resources)
-		if err != nil {
-			t.Errorf("unexpected encoding error: %v", err)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(output)
-	}))
-
-	return server
-}
-
-func setupReconciler(t *testing.T, spec *api.OneAgentSpec) (*ReconcileOneAgent, client.Client, *httptest.Server) {
-	os.Setenv(k8sutil.WatchNamespaceEnvVar, "dynatrace")
-
-	server := initMockServer(t)
-
-	instance := &dynatracev1alpha1.OneAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: *spec,
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "token_test",
-			Namespace: namespace,
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			"paasToken": []byte("42"),
-			"apiToken":  []byte("43"),
-		},
-	}
-
-	scheme := scheme.Scheme
-	scheme.AddKnownTypes(dynatracev1alpha1.SchemeGroupVersion, instance)
-
-	client := fake.NewFakeClient(instance)
-	client.Create(context.TODO(), secret)
-
-	cfg := &restclient.Config{Host: server.URL}
-
-	// reconcile oneagent
-	reconcileOA := &ReconcileOneAgent{client: client, scheme: scheme, config: cfg}
-	reconcileOA.dynatraceClientFunc = mockBuildDynatraceClient
-
-	return reconcileOA, client, server
-}
-
 func TestReconcileOneAgent_ReconcileOnEmptyEnvironment(t *testing.T) {
+	oaName := "oneagent"
 
-	oa := newOneAgentSpec()
-	oa.ApiUrl = testAPIUrl
-	oa.Tokens = "token_test"
-	dynatracev1alpha1.SetDefaults_OneAgentSpec(oa)
+	e, err := newTestEnvironment()
+	assert.NoError(t, err, "failed to start test environment")
 
-	reconcileOA, client, server := setupReconciler(t, oa)
-	defer server.Close()
+	defer e.Stop()
 
-	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-	_, err := reconcileOA.Reconcile(req)
+	e.AddOneAgent(oaName, &dynatracev1alpha1.OneAgentSpec{
+		ApiUrl: DefaultTestAPIURL,
+		Tokens: "token-test",
+	})
 
-	if err != nil {
-		t.Fatalf("error reconciling: %v", err)
-	}
+	_, err = e.Reconciler.Reconcile(newReconciliationRequest(oaName))
+	assert.NoError(t, err, "error reconciling")
 
 	// Check if deamonset has been created and has correct namespace and name.
 	dsActual := &appsv1.DaemonSet{}
-	err = client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dsActual)
-	if err != nil {
-		t.Fatalf("get deamonset: (%v)", err)
-	}
-	if dsActual.Namespace != namespace {
-		t.Errorf("wrong namespace, expected %v, got %v", namespace, dsActual.Namespace)
-	}
-	if dsActual.GetObjectMeta().GetName() != name {
-		t.Errorf("wrong name, expected %v, got %v", name, dsActual.GetObjectMeta().GetName())
-	}
+
+	err = e.Client.Get(context.TODO(), types.NamespacedName{Name: oaName, Namespace: DefaultTestNamespace}, dsActual)
+	assert.NoError(t, err, "failed to get deamonset")
+
+	assert.Equal(t, DefaultTestNamespace, dsActual.Namespace, "wrong namespace")
+	assert.Equal(t, oaName, dsActual.GetObjectMeta().GetName(), "wrong name")
 }


### PR DESCRIPTION
The controller-runtime library, on which the Operator Framework SDK is based on, [recommends using `envtest.Environment`](https://github.com/kubernetes-sigs/controller-runtime/blob/ee41a803ccc9c8a308b751433fc35282c716a9ff/FAQ.md#q-how-should-i-write-tests--any-suggestions-for-getting-started) class to test the behavior of controllers (and operators). This class depends on Kubebuilder, who provides a real instance of the API Server.

Rather than using mocks, the tests have been adapted here to use such envtest.Environment class. For example, we can now query Istio objects from this API Server instance to confirm whether the Operator has created or deleted them as expected. I've also added an additional class to prepare a configured reconciler instance through `newTestEnvironment` which we can use for unit testing, as shown in some tests.

Since we don't need to mock the client anymore, for the generated Istio types, we can remove the Clientset implementation and some others. I'll include that in a follow-up PR.