### PR TITLE
Create appropiate Istio objects for HTTP and IP communication endpoints

### DIFF
--- a/pkg/controller/istio/helper.go
+++ b/pkg/controller/istio/helper.go
@@ -4,17 +4,17 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	istiov1alpha3 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/networking/istio/v1alpha3"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	istio "istio.io/api/networking/v1alpha3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	"net"
 	"os"
 	"strconv"
 	"strings"
-
-	istiov1alpha3 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/networking/istio/v1alpha3"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	istio "istio.io/api/networking/v1alpha3"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
 )
 
 var (
@@ -63,122 +63,117 @@ func BuildServiceEntry(name, host, protocol string, port uint32) *istiov1alpha3.
 	return buildServiceEntryFQDN(name, host, protocol, port)
 }
 
-// BuildServiceEntryFQDN returns an Istio ServiceEntry object for the given communication endpoint with a FQDN host.
-func buildServiceEntryFQDN(name, host, protocol string, port uint32) *istiov1alpha3.ServiceEntry {
-
-	portStr := strconv.Itoa(int(port))
-	protocolStr := strings.ToUpper(protocol)
-
-	spec := istiov1alpha3.ServiceEntrySpec{}
-	spec.Hosts = []string{host}
-	spec.Location = istio.ServiceEntry_MESH_EXTERNAL
-	spec.Ports = []*istio.Port{
-		&istio.Port{
-			Name:     protocol + "-" + portStr,
-			Number:   port,
-			Protocol: protocolStr,
-		},
-	}
-	spec.Resolution = istio.ServiceEntry_DNS
-
-	serviceEntry := &istiov1alpha3.ServiceEntry{
-		Spec: spec,
-	}
-	serviceEntry.Name = name
-	serviceEntry.Namespace = os.Getenv(k8sutil.WatchNamespaceEnvVar)
-
-	return serviceEntry
-}
-
-// BuildServiceEntryIP returns an Istio ServiceEntry object for the given communication endpoint with IP.
-func buildServiceEntryIP(name, host string, port uint32) *istiov1alpha3.ServiceEntry {
-	portStr := strconv.Itoa(int(port))
-
-	spec := istiov1alpha3.ServiceEntrySpec{}
-	spec.Hosts = []string{"ignored.subdomain"}
-	spec.Addresses = []string{host + "/32"}
-	spec.Location = istio.ServiceEntry_MESH_EXTERNAL
-	spec.Ports = []*istio.Port{
-		&istio.Port{
-			Name:     "TCP-" + portStr,
-			Number:   port,
-			Protocol: "TCP",
-		},
-	}
-	spec.Resolution = istio.ServiceEntry_NONE
-
-	serviceEntry := &istiov1alpha3.ServiceEntry{
-		Spec: spec,
-	}
-	serviceEntry.Name = name
-	serviceEntry.Namespace = os.Getenv(k8sutil.WatchNamespaceEnvVar)
-
-	return serviceEntry
-}
-
 // BuildVirtualService returns an Istio VirtualService object for the given communication endpoint.
 func BuildVirtualService(name, host, protocol string, port uint32) *istiov1alpha3.VirtualService {
 	if net.ParseIP(host) != nil { // It's an IP.
 		return nil
 	}
 
-	spec := istiov1alpha3.VirtualServiceSpec{}
-	spec.Hosts = []string{host}
-
-	switch protocol {
-	case "https":
-		spec.Tls = []*istio.TLSRoute{
-			&istio.TLSRoute{
-				Match: []*istio.TLSMatchAttributes{
-					&istio.TLSMatchAttributes{
-						SniHosts: []string{host},
-						Port:     port,
-					},
-				},
-				Route: []*istio.RouteDestination{
-					&istio.RouteDestination{
-						Destination: &istio.Destination{
-							Host: host,
-							Port: &istio.PortSelector{
-								Port: &istio.PortSelector_Number{Number: port},
-							},
-						},
-					},
-				},
-			},
-		}
-	case "http":
-		spec.Http = []*istio.HTTPRoute{
-			&istio.HTTPRoute{
-				Match: []*istio.HTTPMatchRequest{
-					&istio.HTTPMatchRequest{
-						Port: port,
-					},
-				},
-				Route: []*istio.HTTPRouteDestination{
-					&istio.HTTPRouteDestination{
-						Destination: &istio.Destination{
-							Host: host,
-							Port: &istio.PortSelector{
-								Port: &istio.PortSelector_Number{Number: port},
-							},
-						},
-					},
-				},
-			},
-		}
+	return &istiov1alpha3.VirtualService{
+		ObjectMeta: buildObjectMeta(name),
+		Spec: buildVirtualServiceSpec(host, protocol, port),
 	}
-	vs := &istiov1alpha3.VirtualService{
-		Spec: spec,
-	}
-	vs.Name = name
-	vs.Namespace = os.Getenv(k8sutil.WatchNamespaceEnvVar)
+}
 
-	return vs
+// buildServiceEntryFQDN returns an Istio ServiceEntry object for the given communication endpoint with a FQDN host.
+func buildServiceEntryFQDN(name, host, protocol string, port uint32) *istiov1alpha3.ServiceEntry {
+	portStr := strconv.Itoa(int(port))
+	protocolStr := strings.ToUpper(protocol)
+
+	return &istiov1alpha3.ServiceEntry{
+		ObjectMeta: buildObjectMeta(name),
+		Spec: istiov1alpha3.ServiceEntrySpec{
+			ServiceEntry: istio.ServiceEntry{
+				Hosts: []string{host},
+				Ports: []*istio.Port{{
+					Name: protocol + "-" + portStr,
+					Number: port,
+					Protocol: protocolStr,
+				}},
+				Location: istio.ServiceEntry_MESH_EXTERNAL,
+				Resolution: istio.ServiceEntry_DNS,
+			},
+		},
+	}
+}
+
+// buildServiceEntryIP returns an Istio ServiceEntry object for the given communication endpoint with IP.
+func buildServiceEntryIP(name, host string, port uint32) *istiov1alpha3.ServiceEntry {
+	portStr := strconv.Itoa(int(port))
+
+	return &istiov1alpha3.ServiceEntry{
+		ObjectMeta: buildObjectMeta(name),
+		Spec: istiov1alpha3.ServiceEntrySpec{
+			ServiceEntry: istio.ServiceEntry{
+				Hosts: []string{"ignored.subdomain"},
+				Addresses: []string{host + "/32"},
+				Ports: []*istio.Port{{
+					Name: "TCP-" + portStr,
+					Number: port,
+					Protocol: "TCP",
+				}},
+				Location: istio.ServiceEntry_MESH_EXTERNAL,
+				Resolution: istio.ServiceEntry_NONE,
+			},
+		},
+	}
 }
 
 // BuildNameForEndpoint returns a name to be used as a base to identify Istio objects.
 func BuildNameForEndpoint(name string, protocol string, host string, port uint32) string {
 	sum := sha256.Sum256([]byte(fmt.Sprintf("%s-%s-%s-%d", name, protocol, host, port)))
 	return hex.EncodeToString(sum[:])
+}
+
+func buildVirtualServiceSpec(host, protocol string, port uint32) istiov1alpha3.VirtualServiceSpec {
+	virtualServiceSpec := istiov1alpha3.VirtualServiceSpec{}
+	virtualServiceSpec.Hosts = []string{host}
+	switch protocol {
+	case "https":
+		virtualServiceSpec.Tls = buildVirtualServiceTLSRoute(host, port)
+	case "http":
+		virtualServiceSpec.Http = buildVirtualServiceHttpRoute(port, host)
+	}
+
+	return virtualServiceSpec
+}
+
+func buildVirtualServiceTLSRoute(host string, port uint32) []*istio.TLSRoute {
+	return []*istio.TLSRoute{{
+		Match: []*istio.TLSMatchAttributes{{
+			SniHosts: []string{host},
+			Port:     port,
+		}},
+		Route: []*istio.RouteDestination{{
+			Destination: &istio.Destination{
+				Host: host,
+				Port: &istio.PortSelector{
+					Port: &istio.PortSelector_Number{Number: port},
+				},
+			},
+		}},
+	}}
+}
+
+func buildVirtualServiceHttpRoute(port uint32, host string) []*istio.HTTPRoute {
+	return []*istio.HTTPRoute{{
+		Match: []*istio.HTTPMatchRequest{{
+			Port: port,
+		}},
+		Route: []*istio.HTTPRouteDestination{{
+			Destination: &istio.Destination{
+				Host: host,
+				Port: &istio.PortSelector{
+					Port: &istio.PortSelector_Number{Number: port},
+				},
+			},
+		}},
+	}}
+}
+
+func buildObjectMeta(name string) v1.ObjectMeta {
+	return v1.ObjectMeta{
+		Name: name,
+		Namespace: os.Getenv(k8sutil.WatchNamespaceEnvVar),
+	}
 }

--- a/pkg/controller/istio/helper.go
+++ b/pkg/controller/istio/helper.go
@@ -77,7 +77,7 @@ func BuildServiceEntryFQDN(name string, host string, port uint32, protocol strin
         "hosts": [ "` + host + `" ],
         "location": "MESH_EXTERNAL",
         "ports": [{
-            "name": "` + protocol + portStr + `",
+            "name": "` + protocol + "-" + portStr + `",
             "number": ` + portStr + `,
             "protocol": "` + protocolStr + `"
         }],

--- a/pkg/controller/istio/helper_test.go
+++ b/pkg/controller/istio/helper_test.go
@@ -1,12 +1,14 @@
 package istio
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
+	istiov1alpha3 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/networking/istio/v1alpha3"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,96 +104,122 @@ func TestServiceEntryGeneration(t *testing.T) {
 	// TODO: don't use environment variable on BuildServiceEntry
 	os.Setenv(k8sutil.WatchNamespaceEnvVar, "dynatrace")
 
-	assert.Equal(t, `{
-    "apiVersion": "networking.istio.io/v1alpha3",
-    "kind": "ServiceEntry",
-    "metadata": {
-        "name": "com1",
-        "namespace": "dynatrace"
-    },
-    "spec": {
-        "hosts": [ "comtest.com" ],
-        "location": "MESH_EXTERNAL",
-        "ports": [{
-            "name": "https-9999",
-            "number": 9999,
-            "protocol": "HTTPS"
-        }],
-        "resolution": "DNS"
-    }
-}`, string(BuildServiceEntry("com1", "comtest.com", 9999, "https")))
+	seTest1 := bytes.NewBufferString(`{
+		"apiVersion": "networking.istio.io/v1alpha3",
+		"kind": "ServiceEntry",
+		"metadata": {
+			"name": "com1",
+			"namespace": "dynatrace"
+		},
+		"spec": {
+			"hosts": [ "comtest.com" ],
+			"location": "MESH_EXTERNAL",
+			"ports": [{
+				"name": "https-9999",
+				"number": 9999,
+				"protocol": "HTTPS"
+			}],
+			"resolution": "DNS"
+		}
+	}`)
 
-	assert.Equal(t, `{
-    "apiVersion": "networking.istio.io/v1alpha3",
-    "kind": "ServiceEntry",
-    "metadata": {
-        "name": "com1",
-        "namespace": "dynatrace"
-    },
-    "spec": {
-        "hosts": [ "ignored.subdomain" ],
-        "addresses": [ "42.42.42.42/32" ],
-        "location": "MESH_EXTERNAL",
-        "ports": [{
-            "name": "TCP-8888",
-            "number": 8888,
-            "protocol": "TCP"
-        }],
-        "resolution": "NONE"
-    }
-}`, string(BuildServiceEntry("com1", "42.42.42.42", 8888, "https")))
+	se := istiov1alpha3.ServiceEntry{}
+	err := json.Unmarshal(seTest1.Bytes(), &se)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.ObjectsAreEqualValues(&se, (BuildServiceEntry("com1", "comtest.com", "https", 9999)))
+
+	seTest2 := bytes.NewBufferString(`{
+		    "apiVersion": "networking.istio.io/v1alpha3",
+		    "kind": "ServiceEntry",
+		    "metadata": {
+		        "name": "com1",
+		        "namespace": "dynatrace"
+		    },
+		    "spec": {
+		        "hosts": [ "ignored.subdomain" ],
+		        "addresses": [ "42.42.42.42/32" ],
+		        "location": "MESH_EXTERNAL",
+		        "ports": [{
+		            "name": "TCP-8888",
+		            "number": 8888,
+		            "protocol": "TCP"
+		        }],
+		        "resolution": "NONE"
+		    }
+		}`)
+	se = istiov1alpha3.ServiceEntry{}
+	err = json.Unmarshal(seTest2.Bytes(), &se)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.ObjectsAreEqualValues(&se, (BuildServiceEntry("com1", "42.42.42.42", "https", 8888)))
 }
 
 func TestVirtualServiceGeneration(t *testing.T) {
 	// TODO: don't use environment variable on BuildServiceEntry
 	os.Setenv(k8sutil.WatchNamespaceEnvVar, "dynatrace")
+	vsTest1 := bytes.NewBufferString(`{
+		"apiVersion": "networking.istio.io/v1alpha3",
+		"kind": "VirtualService",
+		"metadata": {
+			"name": "com1",
+			"namespace": "dynatrace"
+		},
+		"spec": {
+			"hosts": [ "comtest.com" ],
+			"tls": [{
+				"match": [{
+					"port": 8888,
+					"sni_hosts": [ "comtest.com" ]
+				}],
+				"route": [{
+					"destination": {
+						"host": "comtest.com",
+						"port": { "number": 8888 }
+					}
+				}]
+			}]
+		}
+	}`)
 
-	assert.Equal(t, `{
-    "apiVersion": "networking.istio.io/v1alpha3",
-    "kind": "VirtualService",
-    "metadata": {
-        "name": "com1",
-        "namespace": "dynatrace"
-    },
-    "spec": {
-        "hosts": [ "comtest.com" ],
-        "tls": [{
-            "match": [{
-                "port": 8888,
-                "sni_hosts": [ "comtest.com" ]
-            }],
-            "route": [{
-                "destination": {
-                    "host": "comtest.com",
-                    "port": { "number": 8888 }
-                }
-            }]
-        }]
-    }
-}`, string(BuildVirtualService("com1", "comtest.com", 8888, "https")))
+	vs := istiov1alpha3.VirtualService{}
+	err := json.Unmarshal(vsTest1.Bytes(), &vs)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.ObjectsAreEqualValues(&vs, BuildVirtualService("com1", "comtest.com", "https", 8888))
 
-	assert.Equal(t, `{
-    "apiVersion": "networking.istio.io/v1alpha3",
-    "kind": "VirtualService",
-    "metadata": {
-        "name": "com1",
-        "namespace": "dynatrace"
-    },
-    "spec": {
-        "hosts": [ "comtest.com" ],
-        "http": [{
-            "match": [{
-                "port": 7777
-            }],
-            "route": [{
-                "destination": {
-                    "host": "comtest.com",
-                    "port": { "number": 7777 }
-                }
-            }]
-        }]
-    }
-}`, string(BuildVirtualService("com1", "comtest.com", 7777, "http")))
+	vsTest2 := bytes.NewBufferString(`{
+		"apiVersion": "networking.istio.io/v1alpha3",
+		"kind": "VirtualService",
+		"metadata": {
+			"name": "com1",
+			"namespace": "dynatrace"
+		},
+		"spec": {
+			"hosts": [ "comtest.com" ],
+			"http": [{
+				"match": [{
+					"port": 7777
+				}],
+				"route": [{
+					"destination": {
+						"host": "comtest.com",
+						"port": { "number": 7777 }
+					}
+				}]
+			}]
+		}
+	}`)
 
-	assert.Nil(t, BuildVirtualService("com1", "42.42.42.42", 8888, "HTTP"))
+	vs = istiov1alpha3.VirtualService{}
+	err = json.Unmarshal(vsTest2.Bytes(), &vs)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.ObjectsAreEqualValues(&vs, BuildVirtualService("com1", "comtest.com", "http", 7777))
+
+	assert.Nil(t, BuildVirtualService("com1", "42.42.42.42", "HTTP", 8888))
 }

--- a/pkg/controller/oneagent/istio.go
+++ b/pkg/controller/oneagent/istio.go
@@ -2,13 +2,14 @@ package oneagent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	versionedistioclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/networking/clientset/versioned"
+	istiov1alpha3 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/networking/istio/v1alpha3"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/istio"
+	istiohelper "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/istio"
 	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -18,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func (r *ReconcileOneAgent) reconcileIstio(logger logr.Logger, instance *dynatracev1alpha1.OneAgent, dtc dtclient.Client) (updated bool, ok bool) {
@@ -80,7 +80,7 @@ func (r *ReconcileOneAgent) reconcileIstioConfigurations(
 	role string,
 	logger logr.Logger) (bool, error) {
 
-	add := r.reconcileIstioCreateConfigurations(instance, comHosts, role, logger)
+	add := r.reconcileIstioCreateConfigurations(instance, ic, comHosts, role, logger)
 	rem := r.reconcileIstioRemoveConfigurations(instance, ic, comHosts, role, logger)
 	return add || rem, nil
 }
@@ -99,7 +99,7 @@ func (r *ReconcileOneAgent) reconcileIstioRemoveConfigurations(
 
 	seen := map[string]bool{}
 	for _, ch := range comHosts {
-		seen[istio.BuildNameForEndpoint(instance.Name, ch.Protocol, ch.Host, ch.Port)] = true
+		seen[istiohelper.BuildNameForEndpoint(instance.Name, ch.Protocol, ch.Host, ch.Port)] = true
 	}
 
 	vsUpd := r.removeIstioConfigurationForVirtualService(ic, listOps, seen, logger)
@@ -122,7 +122,6 @@ func (r *ReconcileOneAgent) removeIstioConfigurationForServiceEntry(
 	seen map[string]bool,
 	logger logr.Logger) bool {
 
-	gvk := istio.ServiceEntryGVK
 	namespace := os.Getenv(k8sutil.WatchNamespaceEnvVar)
 
 	list, err := ic.NetworkingV1alpha3().ServiceEntries(namespace).List(*listOps)
@@ -134,7 +133,7 @@ func (r *ReconcileOneAgent) removeIstioConfigurationForServiceEntry(
 	del := false
 	for _, se := range list.Items {
 		if _, inUse := seen[se.GetName()]; !inUse {
-			logger.Info(fmt.Sprintf("istio: removing %s: %v", gvk.Kind, se.GetName()))
+			logger.Info(fmt.Sprintf("istio: removing %s: %v", se.Kind, se.GetName()))
 			err = ic.NetworkingV1alpha3().
 				ServiceEntries(namespace).
 				Delete(se.GetName(), &metav1.DeleteOptions{})
@@ -155,7 +154,6 @@ func (r *ReconcileOneAgent) removeIstioConfigurationForVirtualService(
 	seen map[string]bool,
 	logger logr.Logger) bool {
 
-	gvk := istio.VirtualServiceGVK
 	namespace := os.Getenv(k8sutil.WatchNamespaceEnvVar)
 
 	list, err := ic.NetworkingV1alpha3().VirtualServices(namespace).List(*listOps)
@@ -167,7 +165,7 @@ func (r *ReconcileOneAgent) removeIstioConfigurationForVirtualService(
 	del := false
 	for _, vs := range list.Items {
 		if _, inUse := seen[vs.GetName()]; !inUse {
-			logger.Info(fmt.Sprintf("istio: removing %s: %v", gvk.Kind, vs.GetName()))
+			logger.Info(fmt.Sprintf("istio: removing %s: %v", vs.Kind, vs.GetName()))
 			err = ic.NetworkingV1alpha3().
 				VirtualServices(namespace).
 				Delete(vs.GetName(), &metav1.DeleteOptions{})
@@ -181,19 +179,22 @@ func (r *ReconcileOneAgent) removeIstioConfigurationForVirtualService(
 	return del
 }
 
-func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(instance *dynatracev1alpha1.OneAgent,
-	comHosts []dtclient.CommunicationHost, role string, logger logr.Logger) bool {
+func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(
+	instance *dynatracev1alpha1.OneAgent,
+	ic *versionedistioclient.Clientset,
+	comHosts []dtclient.CommunicationHost,
+	role string, logger logr.Logger) bool {
 
 	created := false
 
 	for _, ch := range comHosts {
-		name := istio.BuildNameForEndpoint(instance.Name, ch.Protocol, ch.Host, ch.Port)
+		name := istiohelper.BuildNameForEndpoint(instance.Name, ch.Protocol, ch.Host, ch.Port)
 
-		if notFound := r.configurationExists(istio.ServiceEntryGVK, instance.Namespace, name); notFound {
-			payload := istio.BuildServiceEntry(name, ch.Host, ch.Port, ch.Protocol)
+		if notFound := r.configurationExists(istiohelper.ServiceEntryGVK, instance.Namespace, name); notFound {
+			serviceEntry := istiohelper.BuildServiceEntry(name, ch.Host, ch.Protocol, ch.Port)
 
 			logger.Info("istio: creating ServiceEntry", "objectName", name, "host", ch.Host, "port", ch.Port)
-			if err := r.reconcileIstioCreateConfiguration(instance, istio.ServiceEntryGVK, role, payload); err != nil {
+			if err := r.createIstioConfigurationForServiceEntry(instance, ic, serviceEntry, role, logger); err != nil {
 				logger.Error(err, "istio: failed to create ServiceEntry")
 				continue
 			}
@@ -201,13 +202,13 @@ func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(instance *dynatra
 		}
 
 		if notFound := r.configurationExists(istio.VirtualServiceGVK, instance.Namespace, name); notFound {
-			payload := istio.BuildVirtualService(name, ch.Host, ch.Port, ch.Protocol)
-			if payload == nil {
+			virtualService := istio.BuildVirtualService(name, ch.Host, ch.Protocol, ch.Port)
+			if virtualService == nil {
 				continue
 			}
 
 			logger.Info("istio: creating VirtualService", "objectName", name, "host", ch.Host, "port", ch.Port, "protocol", ch.Protocol)
-			if err := r.reconcileIstioCreateConfiguration(instance, istio.VirtualServiceGVK, role, payload); err != nil {
+			if err := r.createIstioConfigurationForVirtualService(instance, ic, virtualService, role, logger); err != nil {
 				logger.Error(err, "istio: failed to create VirtualService")
 			}
 			created = true
@@ -217,27 +218,49 @@ func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(instance *dynatra
 	return created
 }
 
-func (r *ReconcileOneAgent) reconcileIstioCreateConfiguration(instance *dynatracev1alpha1.OneAgent,
-	gvk schema.GroupVersionKind, role string, payload []byte) error {
+func (r *ReconcileOneAgent) createIstioConfigurationForServiceEntry(
+	oneagent *dynatracev1alpha1.OneAgent,
+	ic *versionedistioclient.Clientset,
+	serviceEntry *istiov1alpha3.ServiceEntry,
+	role string, logger logr.Logger) error {
 
-	var obj unstructured.Unstructured
-	obj.Object = make(map[string]interface{})
+	namespace := os.Getenv(k8sutil.WatchNamespaceEnvVar)
+	serviceEntry.Labels = buildIstioLabels(oneagent.Name, role)
 
-	if err := json.Unmarshal(payload, &obj.Object); err != nil {
-		return fmt.Errorf("failed to unmarshal json (%s): %v", payload, err)
+	sve, err := ic.NetworkingV1alpha3().ServiceEntries(namespace).Create(serviceEntry)
+	if err != nil {
+		err = fmt.Errorf("istio: error listing service entries, %v", err)
+		logger.Error(err, "istio reconcile")
+		return err
 	}
-
-	obj.SetGroupVersionKind(gvk)
-	obj.SetLabels(buildIstioLabels(instance.Name, role))
-
-	if err := controllerutil.SetControllerReference(instance, &obj, r.scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference: %v", err)
+	if sve == nil {
+		err := fmt.Errorf("Could not create service entry with spec %v", serviceEntry.Spec)
+		logger.Error(err, "istio reconcile")
+		return err
 	}
+	return nil
+}
 
-	if err := r.client.Create(context.TODO(), &obj); err != nil {
-		return fmt.Errorf("failed to create Istio configuration: %v", err)
+func (r *ReconcileOneAgent) createIstioConfigurationForVirtualService(
+	oneagent *dynatracev1alpha1.OneAgent,
+	ic *versionedistioclient.Clientset,
+	virtualService *istiov1alpha3.VirtualService,
+	role string, logger logr.Logger) error {
+
+	namespace := os.Getenv(k8sutil.WatchNamespaceEnvVar)
+	virtualService.Labels = buildIstioLabels(oneagent.Name, role)
+
+	vs, err := ic.NetworkingV1alpha3().VirtualServices(namespace).Create(virtualService)
+	if err != nil {
+		err = fmt.Errorf("istio: error listing service entries, %v", err)
+		logger.Error(err, "istio reconcile")
+		return err
 	}
-
+	if vs == nil {
+		err := fmt.Errorf("Could not create service entry with spec %v", virtualService.Spec)
+		logger.Error(err, "istio reconcile")
+		return err
+	}
 	return nil
 }
 

--- a/pkg/controller/oneagent/istio_test.go
+++ b/pkg/controller/oneagent/istio_test.go
@@ -36,13 +36,8 @@ func TestIstioClient_CreateIstioObjects(t *testing.T) {
 func TestIstioClient_BuildDynatraceVirtualService(t *testing.T) {
 	os.Setenv(k8sutil.WatchNamespaceEnvVar, DefaultTestNamespace)
 
-	buffer := istio.BuildVirtualService("dt-vs", "ENVIRONMENTID.live.dynatrace.com", 443, "https")
-	vs := istiov1alpha3.VirtualService{}
-	err := json.Unmarshal(buffer, &vs)
-	if err != nil {
-		t.Errorf("Failed to marshal json %s", err)
-	}
-	ic := fakeistio.NewSimpleClientset(&vs)
+	vs := istio.BuildVirtualService("dt-vs", "ENVIRONMENTID.live.dynatrace.com", "https", 443)
+	ic := fakeistio.NewSimpleClientset(vs)
 	vsList, err := ic.NetworkingV1alpha3().VirtualServices(DefaultTestNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		t.Errorf("Failed to create VirtualService in %s namespace: %s", DefaultTestNamespace, err)


### PR DESCRIPTION
Wanted to add tests to check the generated objects against the validators on the Istio library, but they are on the middle of refactoring part of the code where these validations are implemented, so will leave it for later.