### PR TITLE
Handle scenario when Istio is installed after the Operator is started

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $ oc delete -n dynatrace oneagent --all
 $ oc delete -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/openshift.yaml
 ```
 
-##### Known Limitation
+## Known Limitation
 If new CRDs are installed after deploying the operator, the operator needs to be restarted.
 This happens due to type cache maintained by controller-runtime's Kubernetes Client. The bug for same is reported here https://github.com/kubernetes-sigs/controller-runtime/issues/321 and the fix for same is currently a work in progress https://github.com/kubernetes-sigs/controller-runtime/pull/554 .
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ $ oc delete -n dynatrace oneagent --all
 $ oc delete -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/openshift.yaml
 ```
 
+##### Known Limitation
+If new CRDs are installed after deploying the operator, the operator needs to be restarted.
+This happens due to type cache maintained by controller-runtime's Kubernetes Client. The bug for same is reported here https://github.com/kubernetes-sigs/controller-runtime/issues/321 and the fix for same is currently a work in progress https://github.com/kubernetes-sigs/controller-runtime/pull/554 .
 
 ## Hacking
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ $ oc delete -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-op
 ```
 
 ## Known Limitation
-If new CRDs are installed after deploying the operator, the operator needs to be restarted.
-This happens due to type cache maintained by controller-runtime's Kubernetes Client. The bug for same is reported here https://github.com/kubernetes-sigs/controller-runtime/issues/321 and the fix for same is currently a work in progress https://github.com/kubernetes-sigs/controller-runtime/pull/554 .
+The `enableIstio` feature requires to restart the operator if Istio was deployed after deployment of the operator in case istio is installed after deploying the operator.
+Background: This happens because the cache maintained by controller-runtime's Kubernetes Client is not dynamic. The bug for same is reported here https://github.com/kubernetes-sigs/controller-runtime/issues/321 and the fix for same is currently a work in progress https://github.com/kubernetes-sigs/controller-runtime/pull/554 .
 
 ## Hacking
 

--- a/pkg/controller/oneagent/istio.go
+++ b/pkg/controller/oneagent/istio.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -190,10 +191,26 @@ func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(
 	for _, ch := range comHosts {
 		name := istiohelper.BuildNameForEndpoint(instance.Name, ch.Protocol, ch.Host, ch.Port)
 
-		if notFound := r.configurationExists(istiohelper.ServiceEntryGVK, instance.Namespace, name); notFound {
+		// Regarding the IsNoMatchError() checks, it's a workaround for,
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/321
+		//
+		// The controller-runtime Client caches CRDs when the process start and doesn't refresh them, so if Istio is
+		// installed into Kubernetes after the Operator instance was started, we'll get errors when querying for
+		// ServiceEntries, etc.
+		//
+		// While there is a pending fix for the bug, since this is a minor edge case, we can suggest to the customer to
+		// restart the Operator pod.
+
+		if notFound, err := r.configurationNotFound(istio.ServiceEntryGVK, instance.Namespace, name); meta.IsNoMatchError(err) {
+			logger.Info("istio: failed to query ServiceEntry: CRD is not registered. Did you install Istio recently? Please restart the Operator")
+			continue
+		} else if err != nil {
+			logger.Error(err, "istio: failed to query ServiceEntry")
+			continue
+		} else if notFound {
+			logger.Info("istio: creating ServiceEntry", "objectName", name, "host", ch.Host, "port", ch.Port)
 			serviceEntry := istiohelper.BuildServiceEntry(name, ch.Host, ch.Protocol, ch.Port)
 
-			logger.Info("istio: creating ServiceEntry", "objectName", name, "host", ch.Host, "port", ch.Port)
 			if err := r.createIstioConfigurationForServiceEntry(instance, ic, serviceEntry, role, logger); err != nil {
 				logger.Error(err, "istio: failed to create ServiceEntry")
 				continue
@@ -201,13 +218,16 @@ func (r *ReconcileOneAgent) reconcileIstioCreateConfigurations(
 			created = true
 		}
 
-		if notFound := r.configurationExists(istio.VirtualServiceGVK, instance.Namespace, name); notFound {
-			virtualService := istio.BuildVirtualService(name, ch.Host, ch.Protocol, ch.Port)
-			if virtualService == nil {
-				continue
-			}
-
+		if notFound, err := r.configurationNotFound(istio.VirtualServiceGVK, instance.Namespace, name); meta.IsNoMatchError(err) {
+			logger.Info("istio: failed to query VirtualService: CRD is not registered. Did you install Istio recently? Please restart the Operator")
+			continue
+		} else if err != nil {
+			logger.Error(err, "istio: failed to query VirtualService")
+			continue
+		} else if notFound {
 			logger.Info("istio: creating VirtualService", "objectName", name, "host", ch.Host, "port", ch.Port, "protocol", ch.Protocol)
+			virtualService := istio.BuildVirtualService(name, ch.Host, ch.Protocol, ch.Port)
+
 			if err := r.createIstioConfigurationForVirtualService(instance, ic, virtualService, role, logger); err != nil {
 				logger.Error(err, "istio: failed to create VirtualService")
 			}
@@ -264,14 +284,20 @@ func (r *ReconcileOneAgent) createIstioConfigurationForVirtualService(
 	return nil
 }
 
-func (r *ReconcileOneAgent) configurationExists(gvk schema.GroupVersionKind, namespace string, name string) bool {
+func (r *ReconcileOneAgent) configurationNotFound(gvk schema.GroupVersionKind, namespace string, name string) (bool, error) {
 	var objQuery unstructured.Unstructured
 	objQuery.Object = make(map[string]interface{})
 
 	objQuery.SetGroupVersionKind(gvk)
 	key := client.ObjectKey{Namespace: namespace, Name: name}
 
-	return errors.IsNotFound(r.client.Get(context.TODO(), key, &objQuery))
+	err := r.client.Get(context.TODO(), key, &objQuery)
+	if err == nil { // Object found.
+		return false, nil
+	} else if errors.IsNotFound(err) { // Object not found.
+		return true, nil
+	}
+	return false, err // Other errors
 }
 
 func buildIstioLabels(name, role string) map[string]string {

--- a/pkg/controller/oneagent/istio.go
+++ b/pkg/controller/oneagent/istio.go
@@ -292,9 +292,14 @@ func (r *ReconcileOneAgent) configurationNotFound(gvk schema.GroupVersionKind, n
 	objQuery.Object = make(map[string]interface{})
 
 	objQuery.SetGroupVersionKind(gvk)
-	key := client.ObjectKey{Namespace: namespace, Name: name}
 
-	err := r.client.Get(context.TODO(), key, &objQuery)
+	var err error
+	if name == "" {
+		err = r.client.List(context.TODO(), &client.ListOptions{Namespace: namespace}, &objQuery)
+	} else {
+		err = r.client.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, &objQuery)
+	}
+
 	if err == nil { // Object found.
 		return false, nil
 	} else if errors.IsNotFound(err) { // Object not found.

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -275,7 +275,10 @@ func (r *ReconcileOneAgent) reconcileVersion(reqLogger logr.Logger, instance *dy
 
 	// determine pods to restart
 	podsToDelete, instances := getPodsToRestart(podList.Items, dtc, instance)
-	if !reflect.DeepEqual(instances, instance.Status.Items) {
+
+	// Workaround: 'instances' can be null, making DeepEqual() return false when comparing against an map instance.
+	// So, compare as long there is data.
+	if (len(instances) > 0 || len(instance.Status.Items) > 0) && !reflect.DeepEqual(instances, instance.Status.Items) {
 		reqLogger.Info("oneagent pod instances changed")
 		updateCR = true
 		instance.Status.Items = instances


### PR DESCRIPTION
Issues handled in this PR - 
* Infinite reconciliation loop while saving CR status when no oneagent pods are running
* Operator needs a restart when istio is deployed after installing oneagent.

Fixes - 
* Infinite reconciliation loop is handled by comparing instances as long as there is data and handling - with a buffer of 30 minutes before requeue request.
* Operator needs to be restarted because RestMapper does not update the new installed CRDs. This issue is open and tracked in [PR on controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/issues/321).