### PR TITLE
Add namespace to clusterrole and clusterrole bindings

### DIFF
--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -282,6 +282,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: dynatrace-oneagent-operator
+  namespace: dynatrace
   labels:
     dynatrace: operator
     operator: oneagent
@@ -299,6 +300,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: dynatrace-oneagent-operator
+  namespace: dynatrace
   labels:
     dynatrace: operator
     operator: oneagent

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -216,6 +216,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: dynatrace-oneagent-operator
+  namespace: dynatrace
   labels:
     dynatrace: operator
     operator: oneagent
@@ -233,6 +234,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: dynatrace-oneagent-operator
+  namespace: dynatrace
   labels:
     dynatrace: operator
     operator: oneagent


### PR DESCRIPTION
Although clusterrole and clusterrolebinding are created in cluster scope, namespace is a mandatory field for metadata