### PR TITLE
Removing noise from logs

### DIFF
--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -117,12 +117,12 @@ type ReconcileOneAgent struct {
 // The NodesController will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	logger := r.logger.WithValues("namespace", request.Namespace, "name", request.Name)
-	logger.Info("reconciling oneagent")
-
 	if len(request.Namespace) == 0 {
 		return reconcile.Result{}, r.nodesController.ReconcileNodes(request.Name)
 	}
+
+	logger := r.logger.WithValues("namespace", request.Namespace, "name", request.Name)
+	logger.Info("reconciling oneagent")
 
 	instance := &dynatracev1alpha1.OneAgent{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)


### PR DESCRIPTION
As we watch the nodes, we get plenty of requests to the controller as state of the nodes keep changing. This causes the logs to be flooded. 

Since, all requests with namespace value empty are handled by nodes-controller, and we do not need to log every single request - we should only log the initialization of reconcile requests when received with adequate namespace - (onagent and istio reconcile workflow). 