### PR TITLE
Backdate marked for termination event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: circleci/golang:1.12
+    - image: circleci/golang:1.13
   working_directory: /go/src/github.com/Dynatrace/dynatrace-oneagent-operator
 
 

--- a/pkg/controller/nodes/controller.go
+++ b/pkg/controller/nodes/controller.go
@@ -133,7 +133,7 @@ func (c *Controller) sendMarkedForTerminationEvent(dtc dtclient.Client, nodeIP s
 		return err
 	}
 
-	tenMinutesAgoInMillis := uint64(time.Now().Add(-10*time.Minute).UnixNano() / 1_000_000)
+	tenMinutesAgoInMillis := c.makeEventStartTimestamp(time.Now())
 	event := &dtclient.EventData{
 		EventType:     dtclient.MarkedForTerminationEvent,
 		Source:        "OneAgent Operator",
@@ -146,6 +146,13 @@ func (c *Controller) sendMarkedForTerminationEvent(dtc dtclient.Client, nodeIP s
 	c.logger.Info("sending mark for termination event to dynatrace server", "node", nodeIP)
 
 	return dtc.SendEvent(event)
+}
+
+func (c *Controller) makeEventStartTimestamp(start time.Time) uint64 {
+	backTime := time.Minute * time.Duration(-10)
+	tenMinutesAgo := start.Add(backTime).UnixNano()
+
+	return uint64(tenMinutesAgo) / uint64(time.Millisecond)
 }
 
 func (c *Controller) buildDynatraceClient(instance *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {

--- a/pkg/controller/nodes/controller.go
+++ b/pkg/controller/nodes/controller.go
@@ -2,6 +2,7 @@ package nodes
 
 import (
 	"context"
+	"time"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	oneagent_utils "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent-utils"
@@ -132,11 +133,12 @@ func (c *Controller) sendMarkedForTerminationEvent(dtc dtclient.Client, nodeIP s
 		return err
 	}
 
+	tenMinutesAgoInMillis := uint64(time.Now().Add(-10*time.Minute).UnixNano() / 1_000_000)
 	event := &dtclient.EventData{
-		EventType:      dtclient.MarkedForTerminationEvent,
-		Source:         "OneAgent Operator",
-		Description:    "Kubernetes node cordoned. Node might be drained or terminated.",
-		TimeoutMinutes: 20,
+		EventType:     dtclient.MarkedForTerminationEvent,
+		Source:        "OneAgent Operator",
+		Description:   "Kubernetes node cordoned. Node might be drained or terminated.",
+		StartInMillis: tenMinutesAgoInMillis,
 		AttachRules: dtclient.EventDataAttachRules{
 			EntityIDs: []string{entityID},
 		},

--- a/pkg/dynatrace-client/send_event.go
+++ b/pkg/dynatrace-client/send_event.go
@@ -14,11 +14,11 @@ const (
 
 // EventData struct which defines what event payload should contain
 type EventData struct {
-	EventType      string               `json:"eventType"`
-	TimeoutMinutes float64              `json:"timeoutMinutes"`
-	Description    string               `json:"description"`
-	AttachRules    EventDataAttachRules `json:"attachRules"`
-	Source         string               `json:"source"`
+	EventType     string               `json:"eventType"`
+	StartInMillis uint64               `json:"start"`
+	Description   string               `json:"description"`
+	AttachRules   EventDataAttachRules `json:"attachRules"`
+	Source        string               `json:"source"`
 }
 
 type EventDataAttachRules struct {

--- a/pkg/dynatrace-client/send_event_test.go
+++ b/pkg/dynatrace-client/send_event_test.go
@@ -11,7 +11,7 @@ import (
 func TestEventDataMarshal(t *testing.T) {
 	testJSONInput := []byte(`{
 		"eventType": "MARKED_FOR_TERMINATION",
-		"timeoutMinutes": 20,
+		"start": 20,
 		"description": "K8s node was marked unschedulable. Node is likely being drained",
 		"attachRules": {
 			"entityIds": [ "HOST-CA78D78BBC6687D3" ]
@@ -35,7 +35,7 @@ func testSendEvent(t *testing.T, dynatraceClient Client) {
 	{
 		testValidEventData := []byte(`{
 			"eventType": "MARKED_FOR_TERMINATION",
-			"timeoutMinutes": 20,
+			"start": 20,
 			"description": "K8s node was marked unschedulable. Node is likely being drained",
 			"attachRules": {
 				"entityIds": [ "HOST-CA78D78BBC6687D3" ]
@@ -51,7 +51,7 @@ func testSendEvent(t *testing.T, dynatraceClient Client) {
 	}
 	{
 		testInvalidEventData := []byte(`{
-			"timeoutMinutes": 20,
+			"start": 20,
 			"description": "K8s node was marked unschedulable. Node is likely being drained",
 			"attachRules": {
 				"entityIds": [ "HOST-CA78D78BBC6687D3" ]
@@ -68,7 +68,7 @@ func testSendEvent(t *testing.T, dynatraceClient Client) {
 	{
 		testExtraKeysEventData := []byte(`{
 			"eventType": "MARKED_FOR_TERMINATION",
-			"timeoutMinutes": 20,
+			"start": 20,
 			"description": "K8s node was marked unschedulable. Node is likely being drained",
 			"attachRules": {
 				"entityIds": [ "HOST-CA78D78BBC6687D3" ]


### PR DESCRIPTION
A _marked for termination_ event sent after an agent stopped sending data is not considered by the problem detection algorithm. This happens in environments without [cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) due to nodes being shut down forcefully.

In order for this event to be picked up by the problem detection algorithm, the timestamp the event happened needs to be set to a value prior to the last message received from the agent. The proposed simple solution sets the timestamp of the event 10 minutes into the past.