### PR TITLE
Update installation instructions for OpenShift

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,17 +133,7 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - checkout
-      - run: sudo chown -R circleci:circleci /usr/local/bin /usr/local/lib/python3.7/site-packages
-      - restore_cache:
-          key: operator-courier-2.1.7
-      - run:
-          command: |
-            sudo pip install operator-courier==2.1.7
-      - save_cache:
-          key: operator-courier-2.1.7
-          paths:
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.7/site-packages"
+      - run: sudo pip install operator-courier==2.1.7
       - run: operator-courier verify ./deploy/olm/kubernetes
       - run: operator-courier verify ./deploy/olm/openshift
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Depending of the version of the Dynatrace OneAgent Operator, it supports the fol
 | Dynatrace OneAgent Operator version | Kubernetes | OpenShift Container Platform |
 | ----------------------------------- | ---------- | ---------------------------- |
 | master                              | 1.11+      | 3.11+                        |
-| v0.4.0                              | 1.11+      | 3.11+                        |
+| v0.4.2                              | 1.11+      | 3.11+                        |
 | v0.3.1                              | 1.11-1.15  | 3.11+                        |
 | v0.2.1                              | 1.9-1.15   | 3.9+                         |
 
@@ -51,6 +51,21 @@ $ kubectl -n dynatrace logs -f deployment/dynatrace-oneagent-operator
 #### OpenShift
 ```sh
 $ oc adm new-project --node-selector="" dynatrace
+```
+
+If you are installing the Operator on an **OpenShift Container Platform 3.11** environment, in order to use the certified [OneAgent Operator](https://access.redhat.com/containers/#/registry.connect.redhat.com/dynatrace/dynatrace-oneagent-operator) and [OneAgent](https://access.redhat.com/containers/#/registry.connect.redhat.com/dynatrace/oneagent) images from [Red Hat Container Catalog](https://access.redhat.com/containers/) (RHCC), you need to [provide image pull secrets](https://access.redhat.com/documentation/en-us/openshift_container_platform/3.9/html/developer_guide/dev-guide-managing-images#pulling-private-registries-delegated-auth). The Service Accounts on the `openshift.yaml` manifest already have links to the secrets to be created below.
+
+```sh
+# For OCP 3.11
+$ oc -n dynatrace create secret docker-registry redhat-connect --docker-server=registry.connect.redhat.com --docker-username=REDHAT_CONNECT_USERNAME --docker-password=REDHAT_CONNECT_PASSWORD --docker-email=unused
+$ oc -n dynatrace create secret docker-registry redhat-connect-sso --docker-server=sso.redhat.com --docker-username=REDHAT_CONNECT_USERNAME --docker-password=REDHAT_CONNECT_PASSWORD --docker-email=unused
+```
+
+Access to the RHCC registry is already available by default on OCP 4.x versions, so the step above is not needed on these environments.
+
+Finally, we apply the `openshift.yaml` manifest to deploy the Operator,
+
+```sh
 $ oc apply -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/openshift.yaml
 $ oc -n dynatrace logs -f deployment/dynatrace-oneagent-operator
 ```
@@ -115,6 +130,8 @@ A secret holding tokens for authenticating to the Dynatrace cluster needs to be 
 Create access tokens of type *Dynatrace API* and *Platform as a Service* and use its values in the following commands respectively.
 For assistance please refere to [Create user-generated access tokens](https://www.dynatrace.com/support/help/get-started/introduction/why-do-i-need-an-access-token-and-an-environment-id/#create-user-generated-access-tokens).
 
+For Openshift, you can change the image from the default available on Quay.io to the one certified on RHCC by setting `.spec.image` to `registry.connect.redhat.com/dynatrace/oneagent` in the custom resource.
+
 Note: `.spec.tokens` denotes the name of the secret holding access tokens. If not specified OneAgent Operator searches for a secret called like the OneAgent custom resource (`.metadata.name`).
 
 ##### Kubernetes
@@ -124,15 +141,6 @@ $ kubectl apply -f cr.yaml
 ```
 
 ##### OpenShift
-In order to use the certified [OneAgent image](https://access.redhat.com/containers/#/registry.connect.redhat.com/dynatrace/oneagent)
-from [Red Hat Container Catalog](https://access.redhat.com/containers/) you need to set `.spec.image` to `registry.connect.redhat.com/dynatrace/oneagent` in the custom resource
-and [provide image pull secrets](https://access.redhat.com/documentation/en-us/openshift_container_platform/3.9/html/developer_guide/dev-guide-managing-images#pulling-private-registries-delegated-auth):
-```sh
-$ oc -n dynatrace create secret docker-registry redhat-connect --docker-server=registry.connect.redhat.com --docker-username=REDHAT_CONNECT_USERNAME --docker-password=REDHAT_CONNECT_PASSWORD --docker-email=unused
-$ oc -n dynatrace create secret docker-registry redhat-connect-sso --docker-server=sso.redhat.com --docker-username=REDHAT_CONNECT_USERNAME --docker-password=REDHAT_CONNECT_PASSWORD --docker-email=unused
-$ oc -n dynatrace secrets link dynatrace-oneagent redhat-connect --for=pull
-$ oc -n dynatrace secrets link dynatrace-oneagent redhat-connect-sso --for=pull
-```
 ```sh
 $ oc -n dynatrace create secret generic oneagent --from-literal="apiToken=DYNATRACE_API_TOKEN" --from-literal="paasToken=PLATFORM_AS_A_SERVICE_TOKEN"
 $ oc apply -f cr.yaml

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ $ kubectl -n dynatrace logs -f deployment/dynatrace-oneagent-operator
 ```
 
 #### OpenShift
+Start by adding a new project as follows:
+
 ```sh
 $ oc adm new-project --node-selector="" dynatrace
 ```
 
-If you are installing the Operator on an **OpenShift Container Platform 3.11** environment, in order to use the certified [OneAgent Operator](https://access.redhat.com/containers/#/registry.connect.redhat.com/dynatrace/dynatrace-oneagent-operator) and [OneAgent](https://access.redhat.com/containers/#/registry.connect.redhat.com/dynatrace/oneagent) images from [Red Hat Container Catalog](https://access.redhat.com/containers/) (RHCC), you need to [provide image pull secrets](https://access.redhat.com/documentation/en-us/openshift_container_platform/3.9/html/developer_guide/dev-guide-managing-images#pulling-private-registries-delegated-auth). The Service Accounts on the `openshift.yaml` manifest already have links to the secrets to be created below.
+If you are installing the Operator on an **OpenShift Container Platform 3.11** environment, in order to use the certified [OneAgent Operator](https://access.redhat.com/containers/#/registry.connect.redhat.com/dynatrace/dynatrace-oneagent-operator) and [OneAgent](https://access.redhat.com/containers/#/registry.connect.redhat.com/dynatrace/oneagent) images from [Red Hat Container Catalog](https://access.redhat.com/containers/) (RHCC), you need to [provide image pull secrets](https://access.redhat.com/documentation/en-us/openshift_container_platform/3.9/html/developer_guide/dev-guide-managing-images#pulling-private-registries-delegated-auth). The Service Accounts on the `openshift.yaml` manifest already have links to the secrets to be created below. Skip this step if you are using OCP 4.x.
 
 ```sh
 # For OCP 3.11
@@ -61,9 +63,7 @@ $ oc -n dynatrace create secret docker-registry redhat-connect --docker-server=r
 $ oc -n dynatrace create secret docker-registry redhat-connect-sso --docker-server=sso.redhat.com --docker-username=REDHAT_CONNECT_USERNAME --docker-password=REDHAT_CONNECT_PASSWORD --docker-email=unused
 ```
 
-Access to the RHCC registry is already available by default on OCP 4.x versions, so the step above is not needed on these environments.
-
-Finally, we apply the `openshift.yaml` manifest to deploy the Operator,
+Finally, for both 4.x and 3.11, we apply the `openshift.yaml` manifest to deploy the Operator:
 
 ```sh
 $ oc apply -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/openshift.yaml

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -3,12 +3,18 @@ kind: ServiceAccount
 metadata:
   name: dynatrace-oneagent-operator
   namespace: dynatrace
+imagePullSecrets:
+- name: redhat-connect
+- name: redhat-connect-sso
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dynatrace-oneagent
   namespace: dynatrace
+imagePullSecrets:
+- name: redhat-connect
+- name: redhat-connect-sso
 ---
 apiVersion: v1
 kind: SecurityContextConstraints


### PR DESCRIPTION
Our `openshift.yaml` refers to the RHCC image in releases. To be able to pull images from RHCC you need to be authenticated against it. On OCP 4.x, the environment is already configured for this, but this may not be the case with OCP 3.x environments.

We do provide instructions on how to authenticate already for the OneAgent service account (used for the OneAgent pods) but we don't indicate the steps for the Operator service account itself. On this PR we're adding the commands to link the imagePullSecrets to the Operator service account.

However, the user adding those secrets after applying `openshift.yaml` would stop the Operator from running at the beginning until such secrets are added. So we'd like for the customer to create the secrets before deploying the Operator, but then the customer wouldn't be able to link the secrets to service accounts that haven't been created until `openshift.yaml` is applied.

To improve this, we're modifying the manifest so that the secrets are linked already, so the customer only needs to create the secrets. This step is optional if your environment is already prepared (e.g., OCP 4.)