### PR TITLE
Handle node notifications for unmatching OneAgent node selectors

### DIFF
--- a/pkg/controller/nodes/controller_test.go
+++ b/pkg/controller/nodes/controller_test.go
@@ -3,16 +3,25 @@ package nodes
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
+	apis "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis"
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	oneagent_utils "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent-utils"
+	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func init() {
+	apis.AddToScheme(scheme.Scheme) // Register OneAgent and Istio object schemas.
+}
+
 func TestDetermineCustomResource(t *testing.T) {
-	node := v1.Node{Spec: v1.NodeSpec{}}
+	node := corev1.Node{Spec: corev1.NodeSpec{}}
 	node.Name = "node_1"
 	nodesController := &Controller{}
 
@@ -79,43 +88,112 @@ func TestDetermineCustomResource(t *testing.T) {
 	}
 }
 
-func TestControllerGetSecret(t *testing.T) {
-	{
-		secret := &v1.Secret{StringData: map[string]string{}}
-		secret.Name = "name"
-		secret.Namespace = "namespace"
-		nc := &Controller{}
-		nc.kubernetesClient = fake.NewSimpleClientset(secret)
+func TestNodesReconciler_NewSchedulableNode(t *testing.T) {
+	nodeName := "new-node"
+	fakeClient := fake.NewFakeClient(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+		})
 
-		s, err := nc.getSecret("name", "namespace")
-		assert.Nil(t, s)
-		assert.Error(t, err, "invalid secret name, missing token paasToken")
-	}
-	{
-		secret := &v1.Secret{StringData: map[string]string{}}
-		secret.Name = "name"
-		secret.Namespace = "namespace"
-		nc := &Controller{}
-		nc.kubernetesClient = fake.NewSimpleClientset(secret)
+	dtClient := &dtclient.MockDynatraceClient{}
 
-		s, err := nc.getSecret("", "")
-		assert.Nil(t, s)
-		assert.Error(t, err, "invalid secret name")
-	}
-	{
-		secret := &v1.Secret{
-			Data: map[string][]byte{
-				"paasToken": []byte("paasToken"),
-				"apiToken":  []byte("apiToken"),
-			}}
-		secret.Name = "name"
-		secret.Namespace = "namespace"
-		nc := &Controller{}
-		nc.kubernetesClient = fake.NewSimpleClientset(secret)
+	nodesController := NewController("dynatrace", fakeClient, staticDynatraceClient(dtClient))
 
-		s, err := nc.getSecret("name", "namespace")
-		assert.NotNil(t, s)
-		assert.NoError(t, err)
-		assert.ObjectsAreEqualValues(secret, s)
+	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
+	assert.Len(t, nodesController.nodeCordonedStatus, 1)
+	assert.Contains(t, nodesController.nodeCordonedStatus, nodeName)
+	assert.False(t, nodesController.nodeCordonedStatus[nodeName])
+	mock.AssertExpectationsForObjects(t, dtClient)
+}
+
+func TestNodesReconciler_UnschedulableNode(t *testing.T) {
+	nodeName := "unschedulable-node"
+	fakeClient := fake.NewFakeClient(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		},
+		&dynatracev1alpha1.OneAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent", Namespace: "dynatrace"},
+			Status: dynatracev1alpha1.OneAgentStatus{
+				Items: map[string]dynatracev1alpha1.OneAgentInstance{
+					nodeName: {IPAddress: "1.2.3.4"},
+				},
+			},
+		})
+
+	dtClient := &dtclient.MockDynatraceClient{}
+	dtClient.On("GetEntityIDForIP", "1.2.3.4").Return("HOST-42", nil)
+	dtClient.On("SendEvent", mock.MatchedBy(func(e *dtclient.EventData) bool {
+		return e.EventType == "MARKED_FOR_TERMINATION"
+	})).Return(nil)
+
+	nodesController := NewController("dynatrace", fakeClient, staticDynatraceClient(dtClient))
+
+	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
+	assert.Len(t, nodesController.nodeCordonedStatus, 1)
+	assert.Contains(t, nodesController.nodeCordonedStatus, nodeName)
+	assert.True(t, nodesController.nodeCordonedStatus[nodeName])
+	mock.AssertExpectationsForObjects(t, dtClient)
+}
+
+func TestNodesReconciler_DeletedNode(t *testing.T) {
+	nodeName := "deleted-node"
+	fakeClient := fake.NewFakeClient(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		},
+		&dynatracev1alpha1.OneAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent", Namespace: "dynatrace"},
+			Spec:       dynatracev1alpha1.OneAgentSpec{},
+			Status: dynatracev1alpha1.OneAgentStatus{
+				Items: map[string]dynatracev1alpha1.OneAgentInstance{
+					nodeName: {IPAddress: "1.2.3.4"},
+				},
+			},
+		})
+
+	dtClient := &dtclient.MockDynatraceClient{}
+	dtClient.On("GetEntityIDForIP", "1.2.3.4").Return("HOST-42", nil)
+	dtClient.On("SendEvent", mock.MatchedBy(func(e *dtclient.EventData) bool {
+		return e.EventType == "MARKED_FOR_TERMINATION"
+	})).Return(nil)
+
+	nodesController := NewController("dynatrace", fakeClient, staticDynatraceClient(dtClient))
+
+	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
+	assert.Len(t, nodesController.nodeCordonedStatus, 1)
+	assert.Contains(t, nodesController.nodeCordonedStatus, nodeName)
+	assert.True(t, nodesController.nodeCordonedStatus[nodeName])
+	mock.AssertExpectationsForObjects(t, dtClient)
+}
+
+func TestNodesReconciler_UnschedulableNodeAndNoMatchingOneAgent(t *testing.T) {
+	nodeName := "unschedulable-node"
+	fakeClient := fake.NewFakeClient(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Spec:       corev1.NodeSpec{Unschedulable: true},
+		},
+		&dynatracev1alpha1.OneAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent", Namespace: "dynatrace"},
+			Spec: dynatracev1alpha1.OneAgentSpec{
+				NodeSelector: map[string]string{"a": "b"},
+			},
+		})
+
+	dtClient := &dtclient.MockDynatraceClient{}
+
+	nodesController := NewController("dynatrace", fakeClient, staticDynatraceClient(dtClient))
+
+	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
+	assert.Empty(t, nodesController.nodeCordonedStatus)
+	mock.AssertExpectationsForObjects(t, dtClient)
+}
+
+func staticDynatraceClient(c dtclient.Client) oneagent_utils.DynatraceClientFunc {
+	return func(_ client.Client, oa *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
+		return c, nil
 	}
 }

--- a/pkg/controller/nodes/controller_test.go
+++ b/pkg/controller/nodes/controller_test.go
@@ -1,12 +1,14 @@
 package nodes
 
 import (
+	"os"
 	"testing"
 
 	apis "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis"
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	oneagent_utils "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent-utils"
 	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +20,7 @@ import (
 
 func init() {
 	apis.AddToScheme(scheme.Scheme) // Register OneAgent and Istio object schemas.
+	os.Setenv(k8sutil.WatchNamespaceEnvVar, "dynatrace")
 }
 
 func TestDetermineCustomResource(t *testing.T) {
@@ -97,7 +100,7 @@ func TestNodesReconciler_NewSchedulableNode(t *testing.T) {
 
 	dtClient := &dtclient.MockDynatraceClient{}
 
-	nodesController := NewController("dynatrace", fakeClient, staticDynatraceClient(dtClient))
+	nodesController := NewController(fakeClient, staticDynatraceClient(dtClient))
 
 	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
 	assert.Len(t, nodesController.nodeCordonedStatus, 1)
@@ -128,7 +131,7 @@ func TestNodesReconciler_UnschedulableNode(t *testing.T) {
 		return e.EventType == "MARKED_FOR_TERMINATION"
 	})).Return(nil)
 
-	nodesController := NewController("dynatrace", fakeClient, staticDynatraceClient(dtClient))
+	nodesController := NewController(fakeClient, staticDynatraceClient(dtClient))
 
 	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
 	assert.Len(t, nodesController.nodeCordonedStatus, 1)
@@ -160,7 +163,7 @@ func TestNodesReconciler_DeletedNode(t *testing.T) {
 		return e.EventType == "MARKED_FOR_TERMINATION"
 	})).Return(nil)
 
-	nodesController := NewController("dynatrace", fakeClient, staticDynatraceClient(dtClient))
+	nodesController := NewController(fakeClient, staticDynatraceClient(dtClient))
 
 	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
 	assert.Len(t, nodesController.nodeCordonedStatus, 1)
@@ -185,7 +188,7 @@ func TestNodesReconciler_UnschedulableNodeAndNoMatchingOneAgent(t *testing.T) {
 
 	dtClient := &dtclient.MockDynatraceClient{}
 
-	nodesController := NewController("dynatrace", fakeClient, staticDynatraceClient(dtClient))
+	nodesController := NewController(fakeClient, staticDynatraceClient(dtClient))
 
 	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
 	assert.Empty(t, nodesController.nodeCordonedStatus)

--- a/pkg/controller/oneagent-utils/verification.go
+++ b/pkg/controller/oneagent-utils/verification.go
@@ -1,16 +1,46 @@
 package oneagent_utils
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
+	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	DynatracePaasToken = "paasToken"
 	DynatraceApiToken  = "apiToken"
 )
+
+// DynatraceClientFunc defines handler func for dynatrace client
+type DynatraceClientFunc func(rtc client.Client, instance *dynatracev1alpha1.OneAgent) (dtclient.Client, error)
+
+// BuildDynatraceClient creates a new Dynatrace client using the settings configured on the given instance.
+func BuildDynatraceClient(rtc client.Client, instance *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
+	secret := &corev1.Secret{}
+	err := rtc.Get(context.TODO(), client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name}, secret)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if err = VerifySecret(secret); err != nil {
+		return nil, err
+	}
+
+	// initialize dynatrace client
+	var certificateValidation = dtclient.SkipCertificateValidation(instance.Spec.SkipCertCheck)
+	apiToken, _ := ExtractToken(secret, DynatraceApiToken)
+	paasToken, _ := ExtractToken(secret, DynatracePaasToken)
+	dtc, err := dtclient.NewClient(instance.Spec.ApiUrl, apiToken, paasToken, certificateValidation)
+
+	return dtc, err
+}
 
 func ExtractToken(secret *v1.Secret, key string) (string, error) {
 	value, ok := secret.Data[key]

--- a/pkg/controller/oneagent-utils/verification.go
+++ b/pkg/controller/oneagent-utils/verification.go
@@ -35,8 +35,17 @@ func BuildDynatraceClient(rtc client.Client, instance *dynatracev1alpha1.OneAgen
 
 	// initialize dynatrace client
 	var certificateValidation = dtclient.SkipCertificateValidation(instance.Spec.SkipCertCheck)
-	apiToken, _ := ExtractToken(secret, DynatraceApiToken)
-	paasToken, _ := ExtractToken(secret, DynatracePaasToken)
+
+	apiToken, err := ExtractToken(secret, DynatraceApiToken)
+	if err != nil {
+		return nil, err
+	}
+
+	paasToken, err := ExtractToken(secret, DynatracePaasToken)
+	if err != nil {
+		return nil, err
+	}
+
 	dtc, err := dtclient.NewClient(instance.Spec.ApiUrl, apiToken, paasToken, certificateValidation)
 
 	return dtc, err

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -53,15 +52,13 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 func NewOneAgentReconciler(client client.Client, scheme *runtime.Scheme, config *rest.Config, logger logr.Logger,
 	dynatraceClientFunc oneagent_utils.DynatraceClientFunc) *ReconcileOneAgent {
 
-	namespace, _ := k8sutil.GetWatchNamespace()
-
 	return &ReconcileOneAgent{
 		client:              client,
 		scheme:              scheme,
 		config:              config,
 		logger:              logger,
 		dynatraceClientFunc: dynatraceClientFunc,
-		nodesController:     nodes.NewController(namespace, client, dynatraceClientFunc),
+		nodesController:     nodes.NewController(client, dynatraceClientFunc),
 		istioController:     istio.NewController(config),
 	}
 }

--- a/pkg/integration_tests/envutils_test.go
+++ b/pkg/integration_tests/envutils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis"
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent"
+	oneagent_utils "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent-utils"
 	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -161,8 +162,8 @@ func newReconciliationRequest(oaName string) reconcile.Request {
 	}
 }
 
-func mockDynatraceClientFunc(communicationHosts *[]string) oneagent.DynatraceClientFunc {
-	return func(oa *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
+func mockDynatraceClientFunc(communicationHosts *[]string) oneagent_utils.DynatraceClientFunc {
+	return func(client client.Client, oa *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
 		commHosts := make([]dtclient.CommunicationHost, len(*communicationHosts))
 		for i, c := range *communicationHosts {
 			commHosts[i] = dtclient.CommunicationHost{Protocol: "https", Host: c, Port: 443}


### PR DESCRIPTION
In case that a cluster where the Operator is deployed on, has an cordoned node, which it's not included in any OneAgent node selector (e.g., a K8s with no OneAgent objects added yet) then the Operator panics.

This PR adds a simple check for that, but I'm also taking the opportunity of testing this and some other scenarios. To simplify testing, I moved the client-go queries to controller-runtime's client, also moved the logic to build the Dynatrace Client object to oneagent-utils.