### PR TITLE
Handle node notifications for unmatching OneAgent node selectors

### DIFF
--- a/pkg/controller/nodes/controller.go
+++ b/pkg/controller/nodes/controller.go
@@ -7,44 +7,37 @@ import (
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	oneagent_utils "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent-utils"
 	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
-
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Controller handles node changes
 type Controller struct {
-	kubernetesClient   kubernetes.Interface
-	config             *rest.Config
-	logger             logr.Logger
-	nodeCordonedStatus map[string]bool
+	client              client.Client
+	logger              logr.Logger
+	nodeCordonedStatus  map[string]bool
+	dynatraceClientFunc oneagent_utils.DynatraceClientFunc
 }
 
 // NewController => returns a new instance of Controller
-func NewController(config *rest.Config) *Controller {
-	c := &Controller{
-		kubernetesClient:   kubernetes.NewForConfigOrDie(config),
-		config:             config,
-		logger:             log.Log.WithName("nodes.controller"),
-		nodeCordonedStatus: make(map[string]bool),
+func NewController(client client.Client, dtcFunc oneagent_utils.DynatraceClientFunc) *Controller {
+	return &Controller{
+		client:              client,
+		logger:              log.Log.WithName("nodes.controller"),
+		nodeCordonedStatus:  make(map[string]bool),
+		dynatraceClientFunc: dtcFunc,
 	}
-
-	return c
 }
 
 // ReconcileNodes => checks if node is marked unschedulable or unavailable
 // and sends adequate event to dynatrace api
 func (c *Controller) ReconcileNodes(nodeName string) error {
-	node, err := c.kubernetesClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	var node corev1.Node
+	err := c.client.Get(context.TODO(), client.ObjectKey{Name: nodeName}, &node)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return c.reconcileCordonedNode(nodeName)
@@ -70,7 +63,11 @@ func (c *Controller) reconcileCordonedNode(nodeName string) error {
 		return err
 	}
 
-	dtc, err := c.buildDynatraceClient(oneAgent)
+	if oneAgent == nil { // If no OneAgent object has been found for node, do nothing.
+		return nil
+	}
+
+	dtc, err := c.dynatraceClientFunc(c.client, oneAgent)
 	if err != nil {
 		return err
 	}
@@ -95,18 +92,13 @@ func (c *Controller) determineOneAgentForNode(nodeName string) (*dynatracev1alph
 }
 
 func (c *Controller) getOneAgentList() (*dynatracev1alpha1.OneAgentList, error) {
-	runtimeClient, err := client.New(c.config, client.Options{})
-	if err != nil {
-		return nil, err
-	}
-
 	watchNamespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		return nil, err
 	}
 
 	var oneAgentList dynatracev1alpha1.OneAgentList
-	err = runtimeClient.List(context.TODO(), &oneAgentList, client.InNamespace(watchNamespace))
+	err = c.client.List(context.TODO(), &oneAgentList, client.InNamespace(watchNamespace))
 	if err != nil {
 		return nil, err
 	}
@@ -153,30 +145,4 @@ func (c *Controller) makeEventStartTimestamp(start time.Time) uint64 {
 	tenMinutesAgo := start.Add(backTime).UnixNano()
 
 	return uint64(tenMinutesAgo) / uint64(time.Millisecond)
-}
-
-func (c *Controller) buildDynatraceClient(instance *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
-	secret, err := c.getSecret(instance.Spec.Tokens, instance.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	var certificateValidation = dtclient.SkipCertificateValidation(instance.Spec.SkipCertCheck)
-	apiToken, _ := oneagent_utils.ExtractToken(secret, oneagent_utils.DynatraceApiToken)
-	paasToken, _ := oneagent_utils.ExtractToken(secret, oneagent_utils.DynatracePaasToken)
-
-	return dtclient.NewClient(instance.Spec.ApiUrl, apiToken, paasToken, certificateValidation)
-}
-
-func (c *Controller) getSecret(name string, namespace string) (*corev1.Secret, error) {
-	secret, err := c.kubernetesClient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
-	if err != nil && errors.IsNotFound(err) {
-		return nil, err
-	}
-
-	if err = oneagent_utils.VerifySecret(secret); err != nil {
-		return nil, err
-	}
-
-	return secret, nil
 }

--- a/pkg/controller/oneagent-utils/verification.go
+++ b/pkg/controller/oneagent-utils/verification.go
@@ -1,10 +1,16 @@
 package oneagent_utils
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
+	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -12,7 +18,40 @@ const (
 	DynatraceApiToken  = "apiToken"
 )
 
-func ExtractToken(secret *v1.Secret, key string) (string, error) {
+// DynatraceClientFunc defines handler func for dynatrace client
+type DynatraceClientFunc func(rtc client.Client, instance *dynatracev1alpha1.OneAgent) (dtclient.Client, error)
+
+// BuildDynatraceClient creates a new Dynatrace client using the settings configured on the given instance.
+func BuildDynatraceClient(rtc client.Client, instance *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
+	secret := &corev1.Secret{}
+	err := rtc.Get(context.TODO(), client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name}, secret)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if err = verifySecret(secret); err != nil {
+		return nil, err
+	}
+
+	// initialize dynatrace client
+	var certificateValidation = dtclient.SkipCertificateValidation(instance.Spec.SkipCertCheck)
+
+	apiToken, err := extractToken(secret, DynatraceApiToken)
+	if err != nil {
+		return nil, err
+	}
+
+	paasToken, err := extractToken(secret, DynatracePaasToken)
+	if err != nil {
+		return nil, err
+	}
+
+	dtc, err := dtclient.NewClient(instance.Spec.ApiUrl, apiToken, paasToken, certificateValidation)
+
+	return dtc, err
+}
+
+func extractToken(secret *v1.Secret, key string) (string, error) {
 	value, ok := secret.Data[key]
 	if !ok {
 		err := fmt.Errorf("missing token %s", key)
@@ -22,9 +61,9 @@ func ExtractToken(secret *v1.Secret, key string) (string, error) {
 	return strings.TrimSpace(string(value)), nil
 }
 
-func VerifySecret(secret *v1.Secret) error {
+func verifySecret(secret *v1.Secret) error {
 	for _, token := range []string{DynatracePaasToken, DynatraceApiToken} {
-		_, err := ExtractToken(secret, token)
+		_, err := extractToken(secret, token)
 		if err != nil {
 			return fmt.Errorf("invalid secret %s, %s", secret.Name, err)
 		}

--- a/pkg/controller/oneagent-utils/verification_test.go
+++ b/pkg/controller/oneagent-utils/verification_test.go
@@ -10,14 +10,14 @@ import (
 func TestExtractToken(t *testing.T) {
 	{
 		secret := corev1.Secret{}
-		_, err := ExtractToken(&secret, "test_token")
+		_, err := extractToken(&secret, "test_token")
 		assert.EqualError(t, err, "missing token test_token")
 	}
 	{
 		data := map[string][]byte{}
 		data["test_token"] = []byte("")
 		secret := corev1.Secret{Data: data}
-		token, err := ExtractToken(&secret, "test_token")
+		token, err := extractToken(&secret, "test_token")
 		assert.NoError(t, err)
 		assert.Equal(t, token, "")
 	}
@@ -25,7 +25,7 @@ func TestExtractToken(t *testing.T) {
 		data := map[string][]byte{}
 		data["test_token"] = []byte("dynatrace_test_token")
 		secret := corev1.Secret{Data: data}
-		token, err := ExtractToken(&secret, "test_token")
+		token, err := extractToken(&secret, "test_token")
 		assert.NoError(t, err)
 		assert.Equal(t, token, "dynatrace_test_token")
 	}
@@ -34,8 +34,8 @@ func TestExtractToken(t *testing.T) {
 		data["test_token"] = []byte("dynatrace_test_token \t \n")
 		data["test_token_2"] = []byte("\t\n   dynatrace_test_token_2")
 		secret := corev1.Secret{Data: data}
-		token, err := ExtractToken(&secret, "test_token")
-		token2, err := ExtractToken(&secret, "test_token_2")
+		token, err := extractToken(&secret, "test_token")
+		token2, err := extractToken(&secret, "test_token_2")
 
 		assert.NoError(t, err)
 		assert.Equal(t, token, "dynatrace_test_token")
@@ -43,22 +43,22 @@ func TestExtractToken(t *testing.T) {
 	}
 }
 
-func TestVerifyToken(t *testing.T) {
+func TestVerifySecret(t *testing.T) {
 	secret := &corev1.Secret{
 		Data: map[string][]byte{},
 	}
 	{
-		err := VerifySecret(secret)
+		err := verifySecret(secret)
 		assert.Error(t, err)
 	}
 	{
 		secret.Data[DynatraceApiToken] = []byte("DynatraceApiToken")
-		err := VerifySecret(secret)
+		err := verifySecret(secret)
 		assert.Error(t, err)
 	}
 	{
 		secret.Data[DynatracePaasToken] = []byte("DynatracePaasToken")
-		err := VerifySecret(secret)
+		err := verifySecret(secret)
 		assert.NoError(t, err)
 	}
 }

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -43,16 +43,13 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	reconciler := NewOneAgentReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetConfig(),
-		log.Log.WithName("oneagent.controller"), nil)
-	reconciler.dynatraceClientFunc = reconciler.buildDynatraceClient
-
-	return reconciler
+	return NewOneAgentReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetConfig(),
+		log.Log.WithName("oneagent.controller"), oneagent_utils.BuildDynatraceClient)
 }
 
 // NewOneAgentReconciler - initialise a new ReconcileOneAgent instance
 func NewOneAgentReconciler(client client.Client, scheme *runtime.Scheme, config *rest.Config, logger logr.Logger,
-	dynatraceClientFunc DynatraceClientFunc) *ReconcileOneAgent {
+	dynatraceClientFunc oneagent_utils.DynatraceClientFunc) *ReconcileOneAgent {
 
 	return &ReconcileOneAgent{
 		client:              client,
@@ -60,7 +57,7 @@ func NewOneAgentReconciler(client client.Client, scheme *runtime.Scheme, config 
 		config:              config,
 		logger:              logger,
 		dynatraceClientFunc: dynatraceClientFunc,
-		nodesController:     nodes.NewController(config),
+		nodesController:     nodes.NewController(client, dynatraceClientFunc),
 		istioController:     istio.NewController(config),
 	}
 }
@@ -93,9 +90,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-// DynatraceClientFunc defines handler func for dynatrace client
-type DynatraceClientFunc func(*dynatracev1alpha1.OneAgent) (dtclient.Client, error)
-
 // ReconcileOneAgent reconciles a OneAgent object
 type ReconcileOneAgent struct {
 	// This client, initialized using mgr.Client() above, is a split client
@@ -105,7 +99,7 @@ type ReconcileOneAgent struct {
 	config *rest.Config
 	logger logr.Logger
 
-	dynatraceClientFunc DynatraceClientFunc
+	dynatraceClientFunc oneagent_utils.DynatraceClientFunc
 	nodesController     *nodes.Controller
 	istioController     *istio.Controller
 }
@@ -154,7 +148,7 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	dtc, err := r.dynatraceClientFunc(instance)
+	dtc, err := r.dynatraceClientFunc(r.client, instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -258,25 +252,6 @@ func (r *ReconcileOneAgent) reconcileRollout(logger logr.Logger, instance *dynat
 	return updateCR, nil
 }
 
-func (r *ReconcileOneAgent) buildDynatraceClient(instance *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
-	secret, err := r.getSecret(instance.Spec.Tokens, instance.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = oneagent_utils.VerifySecret(secret); err != nil {
-		return nil, err
-	}
-
-	// initialize dynatrace client
-	var certificateValidation = dtclient.SkipCertificateValidation(instance.Spec.SkipCertCheck)
-	apiToken, _ := oneagent_utils.ExtractToken(secret, oneagent_utils.DynatraceApiToken)
-	paasToken, _ := oneagent_utils.ExtractToken(secret, oneagent_utils.DynatracePaasToken)
-	dtc, err := dtclient.NewClient(instance.Spec.ApiUrl, apiToken, paasToken, certificateValidation)
-
-	return dtc, err
-}
-
 func (r *ReconcileOneAgent) reconcileVersion(logger logr.Logger, instance *dynatracev1alpha1.OneAgent, dtc dtclient.Client) (bool, error) {
 	updateCR := false
 
@@ -346,20 +321,6 @@ func (r *ReconcileOneAgent) updateCR(instance *dynatracev1alpha1.OneAgent) error
 
 	// Now, with this call we do update the Status section to the new value.
 	return r.client.Status().Update(context.TODO(), instance)
-}
-
-// getSecret retrieves a secret containing PaaS and API tokens for Dynatrace API.
-//
-// Returns an error if the secret is not found.
-func (r *ReconcileOneAgent) getSecret(name string, namespace string) (*corev1.Secret, error) {
-	secret := &corev1.Secret{}
-	key := client.ObjectKey{Namespace: namespace, Name: name}
-	err := r.client.Get(context.TODO(), key, secret)
-	if err != nil && errors.IsNotFound(err) {
-		return &corev1.Secret{}, err
-	}
-
-	return secret, nil
 }
 
 func newDaemonSetForCR(instance *dynatracev1alpha1.OneAgent) *appsv1.DaemonSet {

--- a/pkg/integration_tests/envutils_test.go
+++ b/pkg/integration_tests/envutils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis"
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent"
+	oneagent_utils "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent-utils"
 	dtclient "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dynatrace-client"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -161,8 +162,8 @@ func newReconciliationRequest(oaName string) reconcile.Request {
 	}
 }
 
-func mockDynatraceClientFunc(communicationHosts *[]string) oneagent.DynatraceClientFunc {
-	return func(oa *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
+func mockDynatraceClientFunc(communicationHosts *[]string) oneagent_utils.DynatraceClientFunc {
+	return func(client client.Client, oa *dynatracev1alpha1.OneAgent) (dtclient.Client, error) {
 		commHosts := make([]dtclient.CommunicationHost, len(*communicationHosts))
 		for i, c := range *communicationHosts {
 			commHosts[i] = dtclient.CommunicationHost{Protocol: "https", Host: c, Port: 443}


### PR DESCRIPTION
Follow-up from #160 for the master branch. Additionally to the changes there, `VerifySecret` and `ExtractToken` are now private.