### PR TITLE
Simplify package installation

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.9
 
-RUN apk upgrade --update --no-cache
-RUN apk add ca-certificates
+RUN apk --no-cache add ca-certificates
 
 USER 65534:65534
 


### PR DESCRIPTION
Reduce layers and structure of certification installation by using
one `RUN` directive and combining the arguments.