### PR TITLE
Bump Alpine version to newest minor version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 RUN apk --no-cache add ca-certificates
 


### PR DESCRIPTION
A newer Alpine version has been released.

Bumping in order to get newest packages.

This also fixes CVE-2019-14697 as in alpinelinux/docker-alpine#34