### PR TITLE
Set token as header instead of GET parameter

### DIFF
--- a/pkg/dynatrace-client/agent_version.go
+++ b/pkg/dynatrace-client/agent_version.go
@@ -27,8 +27,9 @@ func (dc *dynatraceClient) GetLatestAgentVersion(os, installerType string) (stri
 		return "", errors.New("os or installerType is empty")
 	}
 
-	resp, err := dc.makeRequest("%s/v1/deployment/installer/agent/%s/%s/latest/metainfo?Api-Token=%s",
-		dc.url, os, installerType, dc.paasToken)
+	resp, err := dc.makeRequest(dc.paasToken,
+		"%s/v1/deployment/installer/agent/%s/%s/latest/metainfo",
+		dc.url, os, installerType)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/dynatrace-client/agent_version.go
+++ b/pkg/dynatrace-client/agent_version.go
@@ -3,6 +3,7 @@ package dynatrace_client
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 )
 
 func (dc *dynatraceClient) GetAgentVersionForIP(ip string) (string, error) {
@@ -27,9 +28,8 @@ func (dc *dynatraceClient) GetLatestAgentVersion(os, installerType string) (stri
 		return "", errors.New("os or installerType is empty")
 	}
 
-	resp, err := dc.makeRequest(dc.paasToken,
-		"%s/v1/deployment/installer/agent/%s/%s/latest/metainfo",
-		dc.url, os, installerType)
+	var url string = fmt.Sprintf("%s/v1/deployment/installer/agent/%s/%s/latest/metainfo", dc.url, os, installerType)
+	resp, err := dc.makeRequest(url, dynatracePaaSToken)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/dynatrace-client/communication_hosts.go
+++ b/pkg/dynatrace-client/communication_hosts.go
@@ -3,6 +3,7 @@ package dynatrace_client
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -19,7 +20,8 @@ func (dc *dynatraceClient) GetCommunicationHostForClient() (CommunicationHost, e
 }
 
 func (dc *dynatraceClient) GetCommunicationHosts() ([]CommunicationHost, error) {
-	resp, err := dc.makeRequest(dc.paasToken, "%s/v1/deployment/installer/agent/connectioninfo", dc.url)
+	var url string = fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dc.url)
+	resp, err := dc.makeRequest(url, dynatracePaaSToken)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dynatrace-client/communication_hosts.go
+++ b/pkg/dynatrace-client/communication_hosts.go
@@ -19,7 +19,7 @@ func (dc *dynatraceClient) GetCommunicationHostForClient() (CommunicationHost, e
 }
 
 func (dc *dynatraceClient) GetCommunicationHosts() ([]CommunicationHost, error) {
-	resp, err := dc.makeRequest("%s/v1/deployment/installer/agent/connectioninfo?Api-Token=%s", dc.url, dc.paasToken)
+	resp, err := dc.makeRequest(dc.paasToken, "%s/v1/deployment/installer/agent/connectioninfo", dc.url)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dynatrace-client/dynatrace_client_test.go
+++ b/pkg/dynatrace-client/dynatrace_client_test.go
@@ -27,12 +27,12 @@ func TestMakeRequest(t *testing.T) {
 	require.NotNil(t, dc)
 
 	{
-		resp, err := dc.makeRequest("%s/v1/deployment/installer/agent/connectioninfo", dc.url)
+		resp, err := dc.makeRequest(apiToken, "%s/v1/deployment/installer/agent/connectioninfo", dc.url)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 	}
 	{
-		resp, err := dc.makeRequest("%s/v1/deployment/installer/agent/connectioninfo", "")
+		resp, err := dc.makeRequest(apiToken, "%s/v1/deployment/installer/agent/connectioninfo", "")
 		assert.Error(t, err, "unsupported protocol scheme")
 		assert.Nil(t, resp)
 	}
@@ -55,7 +55,7 @@ func TestGetResponseOrServerError(t *testing.T) {
 
 	reqURL := "%s/v1/deployment/installer/agent/connectioninfo"
 	{
-		resp, err := dc.makeRequest(reqURL, dc.url)
+		resp, err := dc.makeRequest("", reqURL, dc.url)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 
@@ -64,8 +64,7 @@ func TestGetResponseOrServerError(t *testing.T) {
 		assert.Nil(t, body, "no response body available")
 	}
 	{
-		url := reqURL + "?Api-Token=" + apiToken
-		resp, err := dc.makeRequest(url, dc.url)
+		resp, err := dc.makeRequest(apiToken, reqURL, dc.url)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 

--- a/pkg/dynatrace-client/dynatrace_client_test.go
+++ b/pkg/dynatrace-client/dynatrace_client_test.go
@@ -27,12 +27,13 @@ func TestMakeRequest(t *testing.T) {
 	require.NotNil(t, dc)
 
 	{
-		resp, err := dc.makeRequest(apiToken, "%s/v1/deployment/installer/agent/connectioninfo", dc.url)
+		var url string = fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dc.url)
+		resp, err := dc.makeRequest(url, dynatraceApiToken)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 	}
 	{
-		resp, err := dc.makeRequest(apiToken, "%s/v1/deployment/installer/agent/connectioninfo", "")
+		resp, err := dc.makeRequest("%s/v1/deployment/installer/agent/connectioninfo", dynatraceApiToken)
 		assert.Error(t, err, "unsupported protocol scheme")
 		assert.Nil(t, resp)
 	}
@@ -53,18 +54,9 @@ func TestGetResponseOrServerError(t *testing.T) {
 
 	require.NotNil(t, dc)
 
-	reqURL := "%s/v1/deployment/installer/agent/connectioninfo"
+	reqURL := fmt.Sprintf("%s/v1/deployment/installer/agent/connectioninfo", dc.url)
 	{
-		resp, err := dc.makeRequest("", reqURL, dc.url)
-		assert.NoError(t, err)
-		assert.NotNil(t, resp)
-
-		body, err := dc.getServerResponseData(resp)
-		assert.Error(t, err, "failed to query dynatrace servers")
-		assert.Nil(t, body, "no response body available")
-	}
-	{
-		resp, err := dc.makeRequest(apiToken, reqURL, dc.url)
+		resp, err := dc.makeRequest(reqURL, dynatraceApiToken)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 


### PR DESCRIPTION
We used to provide the tokens (API-Token and PaaS-Token) as GET parameters in the URL.
For security reasons this is now sent as headers.