### PR TITLE
Validate tokens and show results on OneAgent status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Operator log entries now use ISO-8601 timestamps (e.g., `"2019-10-30T12:59:43.717+0100"`) ([#159](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/159))
 * The service account for pods can now be customized ([#182](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/182), [#187](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/187))
 * Custom labels can be added to pods ([#183](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/183))
+* Validate tokens for OneAgent and show results as conditions on OneAgent status section ([#188](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/188))
 
 ### Bug fixes
 

--- a/deploy/crds/dynatrace.com_oneagents_crd.yaml
+++ b/deploy/crds/dynatrace.com_oneagents_crd.yaml
@@ -294,6 +294,16 @@ spec:
                     type: string
                 type: object
               type: object
+            lastAPITokenProbeTimestamp:
+              description: LastAPITokenProbeTimestamp tracks when the last request
+                for the API token validity was sent.
+              format: date-time
+              type: string
+            lastPaaSTokenProbeTimestamp:
+              description: LastPaaSTokenProbeTimestamp tracks when the last request
+                for the PaaS token validity was sent.
+              format: date-time
+              type: string
             phase:
               description: Defines the current state (Running, Updating, Error, ...)
               type: string

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -537,6 +537,16 @@ spec:
                     type: string
                 type: object
               type: object
+            lastAPITokenProbeTimestamp:
+              description: LastAPITokenProbeTimestamp tracks when the last request
+                for the API token validity was sent.
+              format: date-time
+              type: string
+            lastPaaSTokenProbeTimestamp:
+              description: LastPaaSTokenProbeTimestamp tracks when the last request
+                for the PaaS token validity was sent.
+              format: date-time
+              type: string
             phase:
               description: Defines the current state (Running, Updating, Error, ...)
               type: string

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -477,6 +477,16 @@ spec:
                     type: string
                 type: object
               type: object
+            lastAPITokenProbeTimestamp:
+              description: LastAPITokenProbeTimestamp tracks when the last request
+                for the API token validity was sent.
+              format: date-time
+              type: string
+            lastPaaSTokenProbeTimestamp:
+              description: LastPaaSTokenProbeTimestamp tracks when the last request
+                for the PaaS token validity was sent.
+              format: date-time
+              type: string
             phase:
               description: Defines the current state (Running, Updating, Error, ...)
               type: string

--- a/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
+++ b/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
@@ -84,6 +84,10 @@ type OneAgentStatus struct {
 	// +listType=set
 	// +optional
 	Conditions []*OneAgentCondition `json:"conditions,omitempty"`
+	// LastAPITokenProbeTimestamp tracks when the last request for the API token validity was sent.
+	LastAPITokenProbeTimestamp *metav1.Time `json:"lastAPITokenProbeTimestamp,omitempty"`
+	// LastPaaSTokenProbeTimestamp tracks when the last request for the PaaS token validity was sent.
+	LastPaaSTokenProbeTimestamp *metav1.Time `json:"lastPaaSTokenProbeTimestamp,omitempty"`
 }
 
 type OneAgentInstance struct {

--- a/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
+++ b/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
@@ -54,7 +54,7 @@ type OneAgentSpec struct {
 type OneAgentConditionType string
 
 const (
-	ApiTokenConditionType  OneAgentConditionType = "ApiToken"
+	APITokenConditionType  OneAgentConditionType = "APIToken"
 	PaaSTokenConditionType OneAgentConditionType = "PaaSToken"
 )
 
@@ -64,6 +64,22 @@ type OneAgentCondition struct {
 	Reason  string                 `json:"reason"`
 	Message string                 `json:"message"`
 }
+
+// Possible reasons for ApiToken and PaaSToken conditions.
+const (
+	// ReasonTokenReady is set when a token has passed verifications.
+	ReasonTokenReady = "TokenReady"
+	// ReasonTokenSecretNotFound is set when the referenced secret can't be found.
+	ReasonTokenSecretNotFound = "TokenSecretNotFound"
+	// ReasonTokenMissing is set when the field is missing on the secret.
+	ReasonTokenMissing = "TokenMissing"
+	// ReasonTokenUnauthorized is set when a token is unauthorized to query the Dynatrace API.
+	ReasonTokenUnauthorized = "TokenUnauthorized"
+	// ReasonTokenScopeMissing is set when the token is missing the required scope for the Dynatrace API.
+	ReasonTokenScopeMissing = "TokenScopeMissing"
+	// ReasonTokenError is set when an unknown error has been found when verifying the token.
+	ReasonTokenError = "TokenError"
+)
 
 type OneAgentPhaseType string
 
@@ -127,4 +143,32 @@ type OneAgentList struct {
 
 func init() {
 	SchemeBuilder.Register(&OneAgent{}, &OneAgentList{})
+}
+
+// Condition returns OneAgentCondition for the given conditionType
+func (oa *OneAgent) Condition(conditionType OneAgentConditionType) *OneAgentCondition {
+	for i := range oa.Status.Conditions {
+		if oa.Status.Conditions[i].Type == conditionType {
+			return oa.Status.Conditions[i]
+		}
+	}
+
+	condition := OneAgentCondition{Type: conditionType}
+	oa.Status.Conditions = append(oa.Status.Conditions, &condition)
+	return &condition
+}
+
+// SetCondition fills the state for a condition, return true if there were changes on the condition.
+func (oa *OneAgent) SetCondition(condType OneAgentConditionType, status corev1.ConditionStatus, reason, message string) bool {
+	c := oa.Condition(condType)
+	upd := c.Status != status || c.Reason != reason || c.Message != message
+	c.Status = status
+	c.Reason = reason
+	c.Message = message
+	return upd
+}
+
+// SetFailureCondition fills the state for a failing condition
+func (oa *OneAgent) SetFailureCondition(conditionType OneAgentConditionType, reason, message string) bool {
+	return oa.SetCondition(conditionType, corev1.ConditionFalse, reason, message)
 }

--- a/pkg/apis/dynatrace/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/dynatrace/v1alpha1/zz_generated.deepcopy.go
@@ -179,6 +179,14 @@ func (in *OneAgentStatus) DeepCopyInto(out *OneAgentStatus) {
 			}
 		}
 	}
+	if in.LastAPITokenProbeTimestamp != nil {
+		in, out := &in.LastAPITokenProbeTimestamp, &out.LastAPITokenProbeTimestamp
+		*out = (*in).DeepCopy()
+	}
+	if in.LastPaaSTokenProbeTimestamp != nil {
+		in, out := &in.LastPaaSTokenProbeTimestamp, &out.LastPaaSTokenProbeTimestamp
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/dynatrace/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/dynatrace/v1alpha1/zz_generated.openapi.go
@@ -294,6 +294,18 @@ func schema_pkg_apis_dynatrace_v1alpha1_OneAgentStatus(ref common.ReferenceCallb
 							},
 						},
 					},
+					"lastAPITokenProbeTimestamp": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LastAPITokenProbeTimestamp tracks when the last request for the API token validity was sent.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
+					"lastPaaSTokenProbeTimestamp": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LastPaaSTokenProbeTimestamp tracks when the last request for the PaaS token validity was sent.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -2,7 +2,9 @@ package oneagent
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"time"
 
@@ -16,7 +18,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -120,7 +122,7 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 	instance := &dynatracev1alpha1.OneAgent{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Request object not dsActual, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
@@ -154,26 +156,27 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	if err := r.validateSecret(instance); err != nil {
-		return reconcile.Result{}, err
-	}
+	var updateCR bool
 
-	dtc, err := r.dynatraceClientFunc(r.client, instance)
+	dtc, updateCR, err := reconcileDynatraceClient(instance, r.client, r.dynatraceClientFunc, metav1.Now())
+	if updateCR {
+		if err2 := r.updateCR(instance); err2 != nil {
+			if err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to update CR after failure, original, %s, then: %w", err, err2)
+			}
+			return reconcile.Result{}, fmt.Errorf("failed to update CR: %w", err)
+		}
+	}
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if instance.Spec.EnableIstio {
 		upd, ok, err := r.istioController.ReconcileIstio(instance, dtc)
-		if !ok && err != nil {
-			return reconcile.Result{}, nil
-		}
-		if ok && upd {
+		if ok && upd && err != nil {
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 	}
-
-	var updateCR bool
 
 	updateCR, err = r.reconcileRollout(logger, instance, dtc)
 	if err != nil {
@@ -208,44 +211,6 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 	return reconcile.Result{RequeueAfter: 30 * time.Minute}, nil
 }
 
-func (r *ReconcileOneAgent) validateSecret(instance *dynatracev1alpha1.OneAgent) error {
-	secret := &corev1.Secret{}
-	err := r.client.Get(context.TODO(), client.ObjectKey{Namespace: instance.Namespace, Name: instance.Spec.Tokens}, secret)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
-	if errors.IsNotFound(err) {
-		var message = fmt.Sprintf("The secret %s has not been found on namespace %s", instance.Spec.Tokens, instance.Namespace)
-		setStatusCondition(instance, dynatracev1alpha1.ApiTokenConditionType, corev1.ConditionFalse, "TokensSecretNotFound", message)
-		setStatusCondition(instance, dynatracev1alpha1.PaaSTokenConditionType, corev1.ConditionFalse, "TokensSecretNotFound", message)
-	} else {
-		setStatusCondition(instance, dynatracev1alpha1.ApiTokenConditionType, corev1.ConditionTrue, "", "")
-		setStatusCondition(instance, dynatracev1alpha1.PaaSTokenConditionType, corev1.ConditionTrue, "", "")
-	}
-
-	return nil
-}
-
-func setStatusCondition(instance *dynatracev1alpha1.OneAgent, conditionType dynatracev1alpha1.OneAgentConditionType, conditionStatus corev1.ConditionStatus, reason string, message string) {
-	condition := findCondition(instance, conditionType)
-	condition.Status = conditionStatus
-	condition.Reason = reason
-	condition.Message = message
-}
-
-func findCondition(instance *dynatracev1alpha1.OneAgent, conditionType dynatracev1alpha1.OneAgentConditionType) *dynatracev1alpha1.OneAgentCondition {
-	for i := range instance.Status.Conditions {
-		if instance.Status.Conditions[i].Type == conditionType {
-			return instance.Status.Conditions[i]
-		}
-	}
-
-	condition := dynatracev1alpha1.OneAgentCondition{Type: conditionType}
-	instance.Status.Conditions = append(instance.Status.Conditions, &condition)
-	return &condition
-}
-
 func (r *ReconcileOneAgent) reconcileRollout(logger logr.Logger, instance *dynatracev1alpha1.OneAgent, dtc dtclient.Client) (bool, error) {
 	updateCR := false
 
@@ -272,7 +237,7 @@ func (r *ReconcileOneAgent) reconcileRollout(logger logr.Logger, instance *dynat
 	// Check if this DaemonSet already exists
 	dsActual := &appsv1.DaemonSet{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: dsDesired.Name, Namespace: dsDesired.Namespace}, dsActual)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8serrors.IsNotFound(err) {
 		logger.Info("creating new daemonset")
 		err = r.client.Create(context.TODO(), dsDesired)
 		if err != nil {
@@ -309,7 +274,7 @@ func (r *ReconcileOneAgent) determineOneAgentPhase(instance *dynatracev1alpha1.O
 	dsActual := &appsv1.DaemonSet{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, dsActual)
 
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		return false, nil
 	}
 
@@ -533,4 +498,93 @@ func (r *ReconcileOneAgent) waitPodReadyState(instance *dynatracev1alpha1.OneAge
 	}
 
 	return status
+}
+
+func reconcileDynatraceClient(oa *dynatracev1alpha1.OneAgent, c client.Client, dtcFunc utils.DynatraceClientFunc, now metav1.Time) (dtclient.Client, bool, error) {
+	tokens := []*struct {
+		Type              dynatracev1alpha1.OneAgentConditionType
+		Key, Value, Scope string
+		Timestamp         **metav1.Time
+	}{
+		{
+			Type:      dynatracev1alpha1.PaaSTokenConditionType,
+			Key:       utils.DynatracePaasToken,
+			Scope:     dtclient.TokenScopeInstallerDownload,
+			Timestamp: &oa.Status.LastPaaSTokenProbeTimestamp,
+		},
+		{
+			Type:      dynatracev1alpha1.APITokenConditionType,
+			Key:       utils.DynatraceApiToken,
+			Scope:     dtclient.TokenScopeDataExport,
+			Timestamp: &oa.Status.LastAPITokenProbeTimestamp,
+		},
+	}
+
+	updateCR := false
+	secretKey := oa.Namespace + ":" + oa.Spec.Tokens
+	secret := &corev1.Secret{}
+	err := c.Get(context.TODO(), client.ObjectKey{Namespace: oa.Namespace, Name: oa.Spec.Tokens}, secret)
+	if k8serrors.IsNotFound(err) {
+		message := fmt.Sprintf("Secret '%s' not found", secretKey)
+		updateCR = oa.SetFailureCondition(dynatracev1alpha1.APITokenConditionType, dynatracev1alpha1.ReasonTokenSecretNotFound, message) || updateCR
+		updateCR = oa.SetFailureCondition(dynatracev1alpha1.PaaSTokenConditionType, dynatracev1alpha1.ReasonTokenSecretNotFound, message) || updateCR
+		return nil, updateCR, fmt.Errorf(message)
+	}
+
+	if err != nil {
+		return nil, updateCR, err
+	}
+
+	valid := true
+
+	for _, t := range tokens {
+		v := secret.Data[t.Key]
+		if len(v) == 0 {
+			updateCR = oa.SetFailureCondition(t.Type, dynatracev1alpha1.ReasonTokenMissing, fmt.Sprintf("Token %s on secret %s missing", t.Key, secretKey)) || updateCR
+			valid = false
+		}
+		t.Value = string(v)
+	}
+
+	if !valid {
+		return nil, updateCR, fmt.Errorf("issues found with tokens, see status")
+	}
+
+	dtc, err := dtcFunc(c, oa)
+	if err != nil {
+		return nil, updateCR, err
+	}
+
+	for _, t := range tokens {
+		// At this point, we can query the Dynatrace API to verify whether our tokens are correct. To avoid excessive requests,
+		// we wait at least 5 mins between proves.
+		if *t.Timestamp != nil && now.Time.Before((*t.Timestamp).Add(5*time.Minute)) {
+			continue
+		}
+
+		nowCopy := now
+		*t.Timestamp = &nowCopy
+		updateCR = true
+		ss, err := dtc.GetTokenScopes(t.Value)
+
+		var serr dtclient.ServerError
+		if ok := errors.As(err, &serr); ok && serr.Code == http.StatusUnauthorized {
+			oa.SetFailureCondition(t.Type, dynatracev1alpha1.ReasonTokenUnauthorized, fmt.Sprintf("Token on secret %s unauthorized", secretKey))
+			continue
+		}
+
+		if err != nil {
+			oa.SetFailureCondition(t.Type, dynatracev1alpha1.ReasonTokenError, fmt.Sprintf("error when querying token on secret %s: %v", secretKey, err))
+			continue
+		}
+
+		if !ss.Contains(t.Scope) {
+			oa.SetFailureCondition(t.Type, dynatracev1alpha1.ReasonTokenScopeMissing, fmt.Sprintf("Token on secret %s missing scope %s", secretKey, t.Scope))
+			continue
+		}
+
+		oa.SetCondition(t.Type, corev1.ConditionTrue, dynatracev1alpha1.ReasonTokenReady, "Ready")
+	}
+
+	return dtc, updateCR, nil
 }

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -160,9 +160,9 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	dtc, updateCR, err := reconcileDynatraceClient(instance, r.client, r.dynatraceClientFunc, metav1.Now())
 	if updateCR {
-		if err2 := r.updateCR(instance); err2 != nil {
+		if errClient := r.updateCR(instance); errClient != nil {
 			if err != nil {
-				return reconcile.Result{}, fmt.Errorf("failed to update CR after failure, original, %s, then: %w", err, err2)
+				return reconcile.Result{}, fmt.Errorf("failed to update CR after failure, original, %s, then: %w", err, errClient)
 			}
 			return reconcile.Result{}, fmt.Errorf("failed to update CR: %w", err)
 		}

--- a/pkg/controller/oneagent/oneagent_controller_test.go
+++ b/pkg/controller/oneagent/oneagent_controller_test.go
@@ -2,8 +2,10 @@ package oneagent
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	apis "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis"
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
@@ -46,13 +48,13 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 			ObjectMeta: metav1.ObjectMeta{Name: oaName, Namespace: namespace},
 			Spec:       oaSpec,
 		},
-		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: oaName, Namespace: namespace},
-		},
+		NewSecret(oaName, namespace, map[string]string{utils.DynatracePaasToken: "42", utils.DynatraceApiToken: "84"}),
 	)
 
 	dtClient := &dtclient.MockDynatraceClient{}
 	dtClient.On("GetLatestAgentVersion", "unix", "default").Return("42", nil)
+	dtClient.On("GetTokenScopes", "42").Return(dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, nil)
+	dtClient.On("GetTokenScopes", "84").Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport}, nil)
 
 	reconciler := &ReconcileOneAgent{
 		client:              fakeClient,
@@ -71,4 +73,181 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 	assert.Equal(t, oaName, dsActual.GetObjectMeta().GetName(), "wrong name")
 	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dsActual.Spec.Template.Spec.DNSPolicy, "wrong policy")
 	mock.AssertExpectationsForObjects(t, dtClient)
+}
+
+func TestReconcileDynatraceClient_TokenValidation(t *testing.T) {
+	namespace := "dynatrace"
+	oaName := "oneagent"
+	base := dynatracev1alpha1.OneAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: oaName, Namespace: namespace},
+		Spec: dynatracev1alpha1.OneAgentSpec{
+			ApiUrl: "https://ENVIRONMENTID.live.dynatrace.com/api",
+			Tokens: oaName,
+		},
+	}
+	dynatracev1alpha1.SetDefaults_OneAgentSpec(&base.Spec)
+
+	t.Run("No secret", func(t *testing.T) {
+		oa := base.DeepCopy()
+		c := fake.NewFakeClient()
+		dtcMock := &dtclient.MockDynatraceClient{}
+
+		dtc, ucr, err := reconcileDynatraceClient(oa, c, utils.StaticDynatraceClient(dtcMock), metav1.Now())
+		assert.Nil(t, dtc)
+		assert.True(t, ucr)
+		assert.Error(t, err)
+
+		AssertCondition(t, oa, dynatracev1alpha1.PaaSTokenConditionType, false, dynatracev1alpha1.ReasonTokenSecretNotFound,
+			"Secret 'dynatrace:oneagent' not found")
+		AssertCondition(t, oa, dynatracev1alpha1.APITokenConditionType, false, dynatracev1alpha1.ReasonTokenSecretNotFound,
+			"Secret 'dynatrace:oneagent' not found")
+
+		mock.AssertExpectationsForObjects(t, dtcMock)
+	})
+
+	t.Run("PaaS token is empty, API token is missing", func(t *testing.T) {
+		oa := base.DeepCopy()
+		c := fake.NewFakeClient(NewSecret(oaName, namespace, map[string]string{utils.DynatracePaasToken: ""}))
+		dtcMock := &dtclient.MockDynatraceClient{}
+
+		dtc, ucr, err := reconcileDynatraceClient(oa, c, utils.StaticDynatraceClient(dtcMock), metav1.Now())
+		assert.Nil(t, dtc)
+		assert.True(t, ucr)
+		assert.Error(t, err)
+
+		AssertCondition(t, oa, dynatracev1alpha1.PaaSTokenConditionType, false, dynatracev1alpha1.ReasonTokenMissing,
+			"Token paasToken on secret dynatrace:oneagent missing")
+		AssertCondition(t, oa, dynatracev1alpha1.APITokenConditionType, false, dynatracev1alpha1.ReasonTokenMissing,
+			"Token apiToken on secret dynatrace:oneagent missing")
+
+		mock.AssertExpectationsForObjects(t, dtcMock)
+	})
+
+	t.Run("Unauthorized PaaS token, unexpected error for API token request", func(t *testing.T) {
+		oa := base.DeepCopy()
+		c := fake.NewFakeClient(NewSecret(oaName, namespace, map[string]string{utils.DynatracePaasToken: "42", utils.DynatraceApiToken: "84"}))
+
+		dtcMock := &dtclient.MockDynatraceClient{}
+		dtcMock.On("GetTokenScopes", "42").Return(dtclient.TokenScopes(nil), dtclient.ServerError{Code: 401, Message: "Token Authentication failed"})
+		dtcMock.On("GetTokenScopes", "84").Return(dtclient.TokenScopes(nil), fmt.Errorf("random error"))
+
+		dtc, ucr, err := reconcileDynatraceClient(oa, c, utils.StaticDynatraceClient(dtcMock), metav1.Now())
+		assert.Equal(t, dtcMock, dtc)
+		assert.True(t, ucr)
+		assert.NoError(t, err)
+
+		AssertCondition(t, oa, dynatracev1alpha1.PaaSTokenConditionType, false, dynatracev1alpha1.ReasonTokenUnauthorized,
+			"Token on secret dynatrace:oneagent unauthorized")
+		AssertCondition(t, oa, dynatracev1alpha1.APITokenConditionType, false, dynatracev1alpha1.ReasonTokenError,
+			"error when querying token on secret dynatrace:oneagent: random error")
+
+		mock.AssertExpectationsForObjects(t, dtcMock)
+	})
+
+	t.Run("PaaS token has wrong scope, API token is ready", func(t *testing.T) {
+		oa := base.DeepCopy()
+		c := fake.NewFakeClient(NewSecret(oaName, namespace, map[string]string{utils.DynatracePaasToken: "42", utils.DynatraceApiToken: "84"}))
+
+		dtcMock := &dtclient.MockDynatraceClient{}
+		dtcMock.On("GetTokenScopes", "42").Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport}, nil)
+		dtcMock.On("GetTokenScopes", "84").Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport}, nil)
+
+		dtc, ucr, err := reconcileDynatraceClient(oa, c, utils.StaticDynatraceClient(dtcMock), metav1.Now())
+		assert.Equal(t, dtcMock, dtc)
+		assert.True(t, ucr)
+		assert.NoError(t, err)
+
+		AssertCondition(t, oa, dynatracev1alpha1.PaaSTokenConditionType, false, dynatracev1alpha1.ReasonTokenScopeMissing,
+			"Token on secret dynatrace:oneagent missing scope InstallerDownload")
+		AssertCondition(t, oa, dynatracev1alpha1.APITokenConditionType, true, dynatracev1alpha1.ReasonTokenReady, "Ready")
+
+		mock.AssertExpectationsForObjects(t, dtcMock)
+	})
+}
+
+func TestReconcileDynatraceClient_ProbeRequests(t *testing.T) {
+	now := metav1.Now()
+
+	namespace := "dynatrace"
+	oaName := "oneagent"
+	base := dynatracev1alpha1.OneAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: oaName, Namespace: namespace},
+		Spec: dynatracev1alpha1.OneAgentSpec{
+			ApiUrl: "https://ENVIRONMENTID.live.dynatrace.com/api",
+			Tokens: oaName,
+		},
+	}
+	dynatracev1alpha1.SetDefaults_OneAgentSpec(&base.Spec)
+	base.SetCondition(dynatracev1alpha1.APITokenConditionType, corev1.ConditionTrue, dynatracev1alpha1.ReasonTokenReady, "Ready")
+	base.SetCondition(dynatracev1alpha1.PaaSTokenConditionType, corev1.ConditionTrue, dynatracev1alpha1.ReasonTokenReady, "Ready")
+
+	c := fake.NewFakeClient(NewSecret(oaName, namespace, map[string]string{utils.DynatracePaasToken: "42", utils.DynatraceApiToken: "84"}))
+
+	t.Run("No request if last probe was recent", func(t *testing.T) {
+		lastAPIProbe := metav1.NewTime(now.Add(-3 * time.Minute))
+		lastPaaSProbe := metav1.NewTime(now.Add(-3 * time.Minute))
+
+		oa := base.DeepCopy()
+		oa.Status.LastAPITokenProbeTimestamp = &lastAPIProbe
+		oa.Status.LastPaaSTokenProbeTimestamp = &lastPaaSProbe
+
+		dtcMock := &dtclient.MockDynatraceClient{}
+
+		dtc, ucr, err := reconcileDynatraceClient(oa, c, utils.StaticDynatraceClient(dtcMock), now)
+		assert.Equal(t, dtcMock, dtc)
+		assert.False(t, ucr)
+		assert.NoError(t, err)
+		if assert.NotNil(t, oa.Status.LastAPITokenProbeTimestamp) {
+			assert.Equal(t, *oa.Status.LastAPITokenProbeTimestamp, lastAPIProbe)
+		}
+		if assert.NotNil(t, oa.Status.LastPaaSTokenProbeTimestamp) {
+			assert.Equal(t, *oa.Status.LastPaaSTokenProbeTimestamp, lastPaaSProbe)
+		}
+		mock.AssertExpectationsForObjects(t, dtcMock)
+	})
+
+	t.Run("Make request if last probe was not recent", func(t *testing.T) {
+		lastAPIProbe := metav1.NewTime(now.Add(-10 * time.Minute))
+		lastPaaSProbe := metav1.NewTime(now.Add(-10 * time.Minute))
+
+		oa := base.DeepCopy()
+		oa.Status.LastAPITokenProbeTimestamp = &lastAPIProbe
+		oa.Status.LastPaaSTokenProbeTimestamp = &lastPaaSProbe
+
+		dtcMock := &dtclient.MockDynatraceClient{}
+		dtcMock.On("GetTokenScopes", "42").Return(dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, nil)
+		dtcMock.On("GetTokenScopes", "84").Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport}, nil)
+
+		dtc, ucr, err := reconcileDynatraceClient(oa, c, utils.StaticDynatraceClient(dtcMock), now)
+		assert.Equal(t, dtcMock, dtc)
+		assert.True(t, ucr)
+		assert.NoError(t, err)
+		if assert.NotNil(t, oa.Status.LastAPITokenProbeTimestamp) {
+			assert.Equal(t, *oa.Status.LastAPITokenProbeTimestamp, now)
+		}
+		if assert.NotNil(t, oa.Status.LastPaaSTokenProbeTimestamp) {
+			assert.Equal(t, *oa.Status.LastPaaSTokenProbeTimestamp, now)
+		}
+		mock.AssertExpectationsForObjects(t, dtcMock)
+	})
+}
+
+func AssertCondition(t *testing.T, oa *dynatracev1alpha1.OneAgent, ct dynatracev1alpha1.OneAgentConditionType, status bool, reason string, message string) {
+	t.Helper()
+	s := corev1.ConditionFalse
+	if status {
+		s = corev1.ConditionTrue
+	}
+	cond := oa.Condition(ct)
+	assert.Equal(t, s, cond.Status)
+	assert.Equal(t, reason, cond.Reason)
+	assert.Equal(t, message, cond.Message)
+}
+
+func NewSecret(name, namespace string, kv map[string]string) *corev1.Secret {
+	data := make(map[string][]byte)
+	for k, v := range kv {
+		data[k] = []byte(v)
+	}
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}, Data: data}
 }

--- a/pkg/dtclient/agent_version.go
+++ b/pkg/dtclient/agent_version.go
@@ -35,12 +35,9 @@ func (dc *dynatraceClient) GetLatestAgentVersion(os, installerType string) (stri
 	}
 	defer resp.Body.Close()
 
-	responseData, serverError, err := dc.getServerResponseData(resp)
+	responseData, err := dc.getServerResponseData(resp)
 	if err != nil {
 		return "", err
-	}
-	if serverError != nil {
-		return "", errors.New(serverError.Error())
 	}
 
 	return dc.readResponseForLatestVersion(responseData)

--- a/pkg/dtclient/client.go
+++ b/pkg/dtclient/client.go
@@ -49,6 +49,9 @@ type Client interface {
 	//
 	// Returns an error in case the lookup failed.
 	GetEntityIDForIP(ip string) (string, error)
+
+	// GetTokenScopes returns the list of scopes assigned to a token if successful.
+	GetTokenScopes(token string) (TokenScopes, error)
 }
 
 // Known OS values.
@@ -65,6 +68,12 @@ const (
 	InstallerTypeUnattended = "default-unattended"
 	InstallerTypePaasZip    = "paas"
 	InstallerTypePaasSh     = "paas-sh"
+)
+
+// Known token scopes
+const (
+	TokenScopeInstallerDownload = "InstallerDownload"
+	TokenScopeDataExport        = "DataExport"
 )
 
 // NewClient creates a REST client for the given API base URL and authentication tokens.

--- a/pkg/dtclient/client.go
+++ b/pkg/dtclient/client.go
@@ -19,7 +19,7 @@ type Client interface {
 	//  - the agent version is not set or empty
 	GetLatestAgentVersion(os, installerType string) (string, error)
 
-	// GetVersionForIp returns the agent version running on the host with the given IP address.
+	// GetAgentVersionForIP returns the agent version running on the host with the given IP address.
 	// Returns the version string formatted as "Major.Minor.Revision.Timestamp" on success.
 	//
 	// Returns an error for the following conditions:

--- a/pkg/dtclient/communication_hosts.go
+++ b/pkg/dtclient/communication_hosts.go
@@ -27,12 +27,9 @@ func (dc *dynatraceClient) GetCommunicationHosts() ([]CommunicationHost, error) 
 	}
 	defer resp.Body.Close()
 
-	responseData, serverError, err := dc.getServerResponseData(resp)
+	responseData, err := dc.getServerResponseData(resp)
 	if err != nil {
 		return nil, err
-	}
-	if serverError != nil {
-		return nil, errors.New(serverError.Error())
 	}
 
 	return dc.readResponseForConnectionInfo(responseData)

--- a/pkg/dtclient/dynatrace_client_test.go
+++ b/pkg/dtclient/dynatrace_client_test.go
@@ -130,6 +130,7 @@ func TestDynatraceClientWithServer(t *testing.T) {
 	testAgentVersionGetAgentVersionForIP(t, dynatraceClient)
 	testCommunicationHostsGetCommunicationHosts(t, dynatraceClient)
 	testSendEvent(t, dynatraceClient)
+	testGetTokenScopes(t, dynatraceClient)
 }
 
 func dynatraceServerHandler() http.HandlerFunc {
@@ -156,6 +157,8 @@ func handleRequest(request *http.Request, writer http.ResponseWriter) {
 		handleCommunicationHosts(request, writer)
 	case "/v1/events":
 		handleSendEvent(request, writer)
+	case "/v1/tokens/lookup":
+		handleTokenScopes(request, writer)
 	default:
 		writeError(writer, http.StatusBadRequest)
 	}

--- a/pkg/dtclient/dynatrace_client_test.go
+++ b/pkg/dtclient/dynatrace_client_test.go
@@ -60,9 +60,8 @@ func TestGetResponseOrServerError(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 
-		body, serverError, err := dc.getServerResponseData(resp)
+		body, err := dc.getServerResponseData(resp)
 		assert.NoError(t, err)
-		assert.Nil(t, serverError)
 		assert.NotNil(t, body, "response body available")
 	}
 }
@@ -100,41 +99,19 @@ func TestBuildHostCache(t *testing.T) {
 
 func TestServerError(t *testing.T) {
 	{
-		se := &serverError{
-			ErrorMessage: struct {
-				Code    int64
-				Message string
-			}{
-				Code:    401,
-				Message: "Unauthorized",
-			},
-		}
-		assert.Equal(t, se.Error(), "error 401: Unauthorized")
+		se := &ServerError{Code: 401, Message: "Unauthorized"}
+		assert.Equal(t, se.Error(), "dynatrace server error 401: Unauthorized")
 	}
 	{
-		se := &serverError{
-			ErrorMessage: struct {
-				Code    int64
-				Message string
-			}{
-				Message: "Unauthorized",
-			},
-		}
-		assert.Equal(t, se.Error(), "error 0: Unauthorized")
+		se := &ServerError{Message: "Unauthorized"}
+		assert.Equal(t, se.Error(), "dynatrace server error 0: Unauthorized")
 	}
 	{
-		se := &serverError{
-			ErrorMessage: struct {
-				Code    int64
-				Message string
-			}{
-				Code: 401,
-			},
-		}
-		assert.Equal(t, se.Error(), "error 401: ")
+		se := &ServerError{Code: 401}
+		assert.Equal(t, se.Error(), "dynatrace server error 401: ")
 	}
 	{
-		se := &serverError{}
+		se := &ServerError{}
 		assert.Equal(t, se.Error(), "unknown server error")
 	}
 }
@@ -169,18 +146,15 @@ func dynatraceServerHandler() http.HandlerFunc {
 
 func handleRequest(request *http.Request, writer http.ResponseWriter) {
 	latestAgentVersion := fmt.Sprintf("/v1/deployment/installer/agent/%s/%s/latest/metainfo", OsUnix, InstallerTypeDefault)
-	versionForIP := fmt.Sprint("/v1/entity/infrastructure/hosts")
-	communicationHosts := fmt.Sprint("/v1/deployment/installer/agent/connectioninfo")
-	sendEvent := fmt.Sprint("/v1/events")
 
 	switch request.URL.Path {
 	case latestAgentVersion:
 		handleLatestAgentVersion(request, writer)
-	case versionForIP:
+	case "/v1/entity/infrastructure/hosts":
 		handleVersionForIP(request, writer)
-	case communicationHosts:
+	case "/v1/deployment/installer/agent/connectioninfo":
 		handleCommunicationHosts(request, writer)
-	case sendEvent:
+	case "/v1/events":
 		handleSendEvent(request, writer)
 	default:
 		writeError(writer, http.StatusBadRequest)
@@ -188,17 +162,14 @@ func handleRequest(request *http.Request, writer http.ResponseWriter) {
 }
 
 func writeError(w http.ResponseWriter, status int) {
-	message := serverError{
-		ErrorMessage: struct {
-			Code    int64
-			Message string
-		}{
-			Code:    int64(status),
+	message := serverErrorResponse{
+		ErrorMessage: ServerError{
+			Code:    status,
 			Message: "error received from server",
 		},
 	}
 	result, _ := json.Marshal(&message)
 
-	w.WriteHeader(http.StatusMethodNotAllowed)
+	w.WriteHeader(status)
 	_, _ = w.Write(result)
 }

--- a/pkg/dtclient/mock_client.go
+++ b/pkg/dtclient/mock_client.go
@@ -27,7 +27,7 @@ func (o *MockDynatraceClient) GetCommunicationHostForClient() (CommunicationHost
 	return args.Get(0).(CommunicationHost), args.Error(1)
 }
 
-func (o *MockDynatraceClient) SendEvent(event *EventData) (error) {
+func (o *MockDynatraceClient) SendEvent(event *EventData) error {
 	args := o.Called(event)
 	return args.Error(0)
 }
@@ -35,4 +35,9 @@ func (o *MockDynatraceClient) SendEvent(event *EventData) (error) {
 func (o *MockDynatraceClient) GetEntityIDForIP(ip string) (string, error) {
 	args := o.Called(ip)
 	return args.String(0), args.Error(1)
+}
+
+func (o *MockDynatraceClient) GetTokenScopes(token string) (TokenScopes, error) {
+	args := o.Called(token)
+	return args.Get(0).(TokenScopes), args.Error(1)
 }

--- a/pkg/dtclient/send_event.go
+++ b/pkg/dtclient/send_event.go
@@ -49,16 +49,9 @@ func (dc *dynatraceClient) SendEvent(eventData *EventData) error {
 
 	response, err := dc.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error making post request tp dynatrace api: %s", err.Error())
+		return fmt.Errorf("error making post request to dynatrace api: %s", err.Error())
 	}
 
-	_, serverError, err := dc.getServerResponseData(response)
-	if err != nil {
-		return err
-	}
-	if serverError != nil {
-		return errors.New(serverError.Error())
-	}
-
-	return nil
+	_, err = dc.getServerResponseData(response)
+	return err
 }

--- a/pkg/dtclient/token.go
+++ b/pkg/dtclient/token.go
@@ -1,0 +1,65 @@
+package dtclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// TokenScopes is a list of scopes assigned to a token
+type TokenScopes []string
+
+// Contains returns true if scope is included on the scopes, or false otherwise.
+func (s TokenScopes) Contains(scope string) bool {
+	for _, x := range s {
+		if x == scope {
+			return true
+		}
+	}
+	return false
+}
+
+func (dc *dynatraceClient) GetTokenScopes(token string) (TokenScopes, error) {
+	var model struct {
+		Token string `json:"token"`
+	}
+	model.Token = token
+
+	jsonStr, err := json.Marshal(model)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/v1/tokens/lookup", dc.url), bytes.NewBuffer(jsonStr))
+	if err != nil {
+		return nil, fmt.Errorf("error initialising http request: %w", err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", fmt.Sprintf("Api-Token %s", token))
+
+	resp, err := dc.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making post request to dynatrace api: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := dc.getServerResponseData(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return dc.readResponseForTokenScopes(data)
+}
+
+func (dc *dynatraceClient) readResponseForTokenScopes(response []byte) (TokenScopes, error) {
+	var jr struct {
+		Scopes []string `json:"scopes"`
+	}
+
+	if err := json.Unmarshal(response, &jr); err != nil {
+		return nil, fmt.Errorf("error unmarshalling json response: %w", err)
+	}
+
+	return jr.Scopes, nil
+}

--- a/pkg/dtclient/token_test.go
+++ b/pkg/dtclient/token_test.go
@@ -1,0 +1,55 @@
+package dtclient
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testGetTokenScopes(t *testing.T, dynatraceClient Client) {
+	{
+		scopes, err := dynatraceClient.GetTokenScopes("good-token")
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []string{"DataExport", "LogExport"}, scopes)
+	}
+	{
+		scopes, err := dynatraceClient.GetTokenScopes("bad-token")
+		assert.Nil(t, scopes)
+		assert.Error(t, err)
+		assert.Exactly(t, ServerError{Code: 401, Message: "error received from server"}, err)
+	}
+}
+
+func handleTokenScopes(request *http.Request, writer http.ResponseWriter) {
+	var model struct {
+		Token string `json:"token"`
+	}
+
+	defer request.Body.Close()
+	d, _ := ioutil.ReadAll(request.Body)
+	json.Unmarshal(d, &model)
+
+	if request.Method != "POST" {
+		writeError(writer, http.StatusMethodNotAllowed)
+		return
+	}
+
+	switch model.Token {
+	case "good-token":
+		writer.WriteHeader(http.StatusOK)
+		writer.Write([]byte(`{
+			"id": "f7060574-e8cf-4bc2-a9e0-307517ca9957",
+			"name": "the-token",
+			"userId": "the-user",
+			"scopes": [
+				"DataExport",
+				"LogExport"
+			]
+		}`))
+	default:
+		writeError(writer, http.StatusUnauthorized)
+	}
+}

--- a/pkg/integrationtests/envutils_test.go
+++ b/pkg/integrationtests/envutils_test.go
@@ -177,6 +177,8 @@ func mockDynatraceClientFunc(communicationHosts *[]string) utils.DynatraceClient
 			Host:     DefaultTestAPIURL,
 			Port:     443,
 		}, nil)
+		dtc.On("GetTokenScopes", "42").Return(dtclient.TokenScopes{dtclient.TokenScopeInstallerDownload}, nil)
+		dtc.On("GetTokenScopes", "43").Return(dtclient.TokenScopes{dtclient.TokenScopeDataExport}, nil)
 
 		return dtc, nil
 	}


### PR DESCRIPTION
# Description

Since having mis-configured tokens with OneAgent objects is a relatively common scenario. The idea with this PR is for the Operator to validate different common situations and provide a place where users can look for issues, if any.

The OneAgent CRD now has two conditions, `PaaSToken` and `APIToken`, to indicate the state of the API and PaaS tokens, respectively, and can be looked at with `kubectl get oneagent -o yaml` or `kubectl describe oneagent`.

The Operator will now set different reasons for each condition depending of the validation result:

#### TokenReady

Set when all checks have passed.

```
- type: PaaSToken
  status: "True"
  reason: TokenReady
  message: Ready
```

#### TokenSecretNotFound

When the secret doesn't exist. By the default it comes from the OneAgent object name, and can be customized by the CR field `tokens`.

```
- type: PaaSToken
  status: "False"
  reason: TokenSecretNotFound
  message: Secret 'dynatrace:custom-oneagent-token' not found
```

#### TokenMissing

Set when the token field is missing on the secret. Two fields must be on the secret, `apiToken`, and `paasToken`.

```
- type: APIToken
  status: "False"
  reason: TokenMissing
  message: Token apiToken on secret dynatrace:custom-oneagent-token missing
```

#### TokenUnauthorized

When the token can't be found in the Dynatrace environment. Is it correct?

```
- type: APIToken
  status: "False"
  reason: TokenUnauthorized
  message: Token on secret dynatrace:custom-oneagent-token unauthorized
```

#### TokenScopeMissing

Set when the token doesn't have the required permission on Dynatrace environment, e.g., using API token on the PaaS token field, etc. Currently, API and PaaS tokens need `DataExport`, and `InstallerDownload`, respectively.

```
- type: APIToken
  status: "False"
  reason: TokenScopeMissing
  message: Token on secret dynatrace:custom-oneagent-token missing scope DataExport
```

#### TokenError

Set when the probe request failed by an unrecognized error. Is it the API URL correct?

```
- type: PaaSToken
  status: "False"
  reason: TokenError
  message: 'error when querying token on secret dynatrace:custom-oneagent-token:
    error making post request to dynatrace api: Post https://wrong.domain.com/api/v1/tokens/lookup:
    dial tcp: lookup wrong.domain.com on 1.2.3.4:53: no
    such host'
```

# Implementation details

* To verify whether a token is valid, we make a request against the Dynatrace API for that token, which returns the assigned permissions (scopes).
* To try to avoid reconciliation loops trying to make DDoS over the API, we wait 5 minutes before a new request.
  * To keep track of the timestamps, two fields have been added to the CRD Status schema, `LastAPITokenProbeTimestamp`, and `LastPaaSTokenProbeTimestamp`.
* The Operator's workflow remains as before, so, if for example, the API token is invalid, that won't stop the Operator from creating the DaemonSet (version update checks will still fail of course.)
* Moved `setStatusCondition()` and `findCondition()` from the reconciler to be `OneAgent`'s methods.
* Regarding the Dynatrace Client, I've made `ServerError` to be an error type. If specific behavior is needed with these kind of errors, the Go 1.13's `errors` package can be used.