### PR TITLE
Don't modify DaemonSet selector labels when using custom labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add OpenAPI V3 Schema to CRD objects ([#171](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/171))
 * Operator log entries now use ISO-8601 timestamps (e.g., `"2019-10-30T12:59:43.717+0100"`) ([#159](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/159))
 * The service account for pods can now be customized ([#182](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/182), [#187](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/187))
-* Custom labels can be added to pods ([#183](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/183))
+* Custom labels can be added to pods ([#183](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/183), [#191](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/191))
 * Validate tokens for OneAgent and show results as conditions on OneAgent status section ([#188](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/188), [#190](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/190))
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -129,10 +129,8 @@ spec:
   # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   #dnsPolicy: ""
   # Labels are customer defined labels for oneagent pods to structure workloads as desired
-  #labels: 
-  #  dynatrace : value1
-  #  one-agent : value2
-  #  tenant-id : value3
+  #labels:
+  #  custom: label
   # Name of the service account for the OneAgent (optional)
   #serviceAccountName: "dynatrace-oneagent"
 ```

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -53,9 +53,7 @@ spec:
   # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   #dnsPolicy: ""
   # Labels are customer defined labels for oneagent pods to structure workloads as desired
-  #labels: 
-  #  dynatrace : value1
-  #  one-agent : value2
-  #  tenant-id : value3
+  #labels:
+  #  custom: label
   # Name of the service account for the OneAgent (optional)
   #serviceAccountName: "dynatrace-oneagent"


### PR DESCRIPTION
The Label Selector is immutable once the DaemonSet is created. So, to allow changes on the CR's `labels` here we leave the label selector to just the usual `dynatrace` and `oneagent` labels, and only replace the object labels on the Pods and DaemonSet.