### PR TITLE
Use reader from mgr.GetApiReader() for querying the OneAgent object

### DIFF
--- a/pkg/controller/oneagent/oneagent_controller_test.go
+++ b/pkg/controller/oneagent/oneagent_controller_test.go
@@ -58,6 +58,7 @@ func TestReconcileOneAgent_ReconcileOnEmptyEnvironmentAndDNSPolicy(t *testing.T)
 
 	reconciler := &ReconcileOneAgent{
 		client:              fakeClient,
+		apiReader:           fakeClient,
 		scheme:              scheme.Scheme,
 		logger:              logf.ZapLoggerTo(os.Stdout, true),
 		dynatraceClientFunc: utils.StaticDynatraceClient(dtClient),

--- a/pkg/integrationtests/envutils_test.go
+++ b/pkg/integrationtests/envutils_test.go
@@ -131,7 +131,7 @@ func newTestEnvironment() (*ControllerTestEnvironment, error) {
 		Client:             kubernetesClient,
 		CommunicationHosts: communicationHosts,
 	}
-	environment.Reconciler = oneagent.NewOneAgentReconciler(kubernetesClient, scheme.Scheme, cfg,
+	environment.Reconciler = oneagent.NewOneAgentReconciler(kubernetesClient, kubernetesClient, scheme.Scheme, cfg,
 		logf.ZapLoggerTo(os.Stdout, true), mockDynatraceClientFunc(&environment.CommunicationHosts))
 
 	return environment, nil


### PR DESCRIPTION
Querying the OneAgent object was done with the client received by `mgr.GetClient()`. For fast reconciliation cycles, where the OneAgent object is modified and read again, the client might return an out of fdate OneAgent object from the cahce, resulting in following error message:
```json
{
    "level": "error",
    "ts": 1573211855.705202,
    "logger": "kubebuilder.controller",
    "msg": "Reconciler error",
    "controller": "oneagent-controller",
    "request": "dynatrace/oneagent",
    "error": "Operation cannot be fulfilled on oneagents.dynatrace.com \"oneagent\": the object has been modified; please apply your changes to the latest version and try again",
}
```

To prevent this issue a client instance that does not use caching is provided via `mgr.GetApiReader()`. This instance is now used to query the OneAgent object in the reconciliation loop.