### PR TITLE
Set status phase value during the reconciliation loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 * Separated the logic for watching the nodes into nodes_controller to handle scaling correctly ([#189](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/189)) 
+* Show operator phase in the `status.phase` field of the OneAgent object ([#197](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/197))
 
 ### Bug fixes
 * Fix error messages because of unnecessary watch for nodes in oneagent controller ([#196](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/196))

--- a/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
+++ b/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
@@ -172,3 +172,18 @@ func (oa *OneAgent) SetCondition(condType OneAgentConditionType, status corev1.C
 func (oa *OneAgent) SetFailureCondition(conditionType OneAgentConditionType, reason, message string) bool {
 	return oa.SetCondition(conditionType, corev1.ConditionFalse, reason, message)
 }
+
+// SetPhase sets the status phase on the OneAgent object
+func (oa *OneAgent) SetPhase(phase OneAgentPhaseType) bool {
+	upd := phase != oa.Status.Phase
+	oa.Status.Phase = phase
+	return upd
+}
+
+// SetPhaseOnError fills the phase with the Error value in case of any error
+func (oa *OneAgent) SetPhaseOnError(err error) bool {
+	if err != nil {
+		return oa.SetPhase(Error)
+	}
+	return false;
+}


### PR DESCRIPTION
This PR adds a value for `status.phase` to the OneAgent object. The value is set to 
* `Error` in case any error happens during the reconciliation loop
* `Deploying` when the operator updates the OneAgent pods/DaemonSet
* `Running` when everything is up to date and running