### PR TITLE
Use node affinity to schedule pods on supported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   Operation cannot be fulfilled on oneagents.dynatrace.com \"oneagent\": the object has been modified; please apply your changes to the latest version and try again
   ```
 
+### Other changes
+* Support deprecation of `beta.kubernetes.io/arch` and `beta.kubernetes.io/os` labels ([#199](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/199))
+
 ## v0.6
 
 ### Features

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -582,9 +582,28 @@ spec:
             limits:
               cpu: 100m
               memory: 256Mi
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-        beta.kubernetes.io/arch: amd64
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       serviceAccountName: dynatrace-oneagent-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -44,7 +44,26 @@ spec:
             limits:
               cpu: 100m
               memory: 256Mi
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-        beta.kubernetes.io/arch: amd64
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       serviceAccountName: dynatrace-oneagent-operator

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -522,9 +522,28 @@ spec:
             limits:
               cpu: 100m
               memory: 256Mi
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-        beta.kubernetes.io/arch: amd64
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       serviceAccountName: dynatrace-oneagent-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -44,7 +44,26 @@ spec:
             limits:
               cpu: 100m
               memory: 256Mi
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-        beta.kubernetes.io/arch: amd64
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       serviceAccountName: dynatrace-oneagent-operator

--- a/pkg/apis/dynatrace/v1alpha1/defaults.go
+++ b/pkg/apis/dynatrace/v1alpha1/defaults.go
@@ -17,13 +17,6 @@ func SetDefaults_OneAgentSpec(obj *OneAgentSpec) {
 		obj.Image = "docker.io/dynatrace/oneagent:latest"
 	}
 
-	if _, ok := obj.NodeSelector["beta.kubernetes.io/os"]; !ok {
-		if obj.NodeSelector == nil {
-			obj.NodeSelector = make(map[string]string)
-		}
-		obj.NodeSelector["beta.kubernetes.io/os"] = "linux"
-	}
-
 	if obj.ServiceAccountName == "" {
 		obj.ServiceAccountName = "dynatrace-oneagent"
 	}

--- a/pkg/apis/dynatrace/v1alpha1/defaults_test.go
+++ b/pkg/apis/dynatrace/v1alpha1/defaults_test.go
@@ -11,7 +11,6 @@ func TestSetDefaults_OneAgentSpec(t *testing.T) {
 	SetDefaults_OneAgentSpec(oa)
 	assert.NotNil(t, oa.WaitReadySeconds)
 	assert.NotEmpty(t, oa.Image)
-	assert.NotEmpty(t, oa.NodeSelector)
 	assert.NotEmpty(t, oa.Env)
 }
 


### PR DESCRIPTION
The `beta.kubernetes.io/arch` and `beta.kubernetes.io/os` labels [have been deprecated](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#deprecations), and `kubernetes.io`-named labels, added on Kubernetes 1.14, are now recommended instead.

This PR replaces the node selectors using the old labels with node affinity for more flexibility so that we can handle both old and new Kubernetes versions, once the beta-labels are removed (Kubernetes 1.18, supposedly.)

Technically, this is a breaking change, since customers can't now use a `beta.kubernetes.io/os` value other than `linux` since the affinity is not currently customizable on the CR. Although, is this an actual use case?

Either way, we should support custom affinities on the CR, but I'll leave it for a later PR.