### PR TITLE
Clone default transport when skipping cert validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   ```
   Operation cannot be fulfilled on oneagents.dynatrace.com \"oneagent\": the object has been modified; please apply your changes to the latest version and try again
   ```
+* Proxy environment variables (e.g., `http_proxy`, etc.) can be ignored on Operator container when `skipCertCheck` is true ([#204](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/204))
 
 ### Other changes
 * As part of the support for ARM ([#201](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/201), [#203](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/203))


### PR DESCRIPTION
When disabling certificate validation we're creating a new transport, which it's *not* the same as the default transport. In fact, proxy settings from the environment variables are ignored.

With this PR, I'm cloning the default transport, and creating a client for this use-case. Also, note that according to the Go's documentation, we should only create clients and transports once and reuse them, hence what I'm do here.