### PR TITLE
Update Readme instruction to install stable releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Operator needs to be restarted after Istio is installed. Fixed on [controller-runtime v0.3.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.3.0) ([#172](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/172), [controller-runtime#554](https://github.com/kubernetes-sigs/controller-runtime/pull/554))
 
 ### Other changes
+* Installation steps on Readme are now for stable releases ([#205](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/205))
 * Most operations now use HTTP Header for authentication with Dynatrace API ([#167](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/167))
 * Operator Docker images have been merged, and are now based on [UBI](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image) ([#179](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/179))
 * Update to nested OLM bundle structure ([#163](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/163))

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,6 +6,22 @@
 OneAgent Operator. The `operator-sdk` tool needs to be installed upfront as outlined in the
 [Operator SDK User Guide](https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#install-the-operator-sdk-cli).
 
+### Installation
+
+There are automatic builds from the master branch. The latest development build can be installed on Kubernetes with,
+
+#### Kubernetes
+```sh
+$ kubectl create namespace dynatrace
+$ kubectl apply -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/kubernetes.yaml
+```
+
+#### OpenShift
+```sh
+$ oc adm new-project --node-selector="" dynatrace
+$ oc apply -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/openshift.yaml
+```
+
 #### Tests
 
 The unit tests can be executed with

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Create neccessary objects and observe its logs:
 #### Kubernetes
 ```sh
 $ kubectl create namespace dynatrace
-$ kubectl apply -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/kubernetes.yaml
+$ LATEST_RELEASE=$(curl -s https://api.github.com/repos/dynatrace/dynatrace-oneagent-operator/releases/latest | grep tag_name | cut -d '"' -f 4)
+$ kubectl apply -f https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/download/$LATEST_RELEASE/kubernetes.yaml
 $ kubectl -n dynatrace logs -f deployment/dynatrace-oneagent-operator
 ```
 
@@ -68,7 +69,8 @@ $ oc -n dynatrace create secret docker-registry redhat-connect-sso --docker-serv
 Finally, for both 4.x and 3.11, we apply the `openshift.yaml` manifest to deploy the Operator:
 
 ```sh
-$ oc apply -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/openshift.yaml
+$ LATEST_RELEASE=$(curl -s https://api.github.com/repos/dynatrace/dynatrace-oneagent-operator/releases/latest | grep tag_name | cut -d '"' -f 4)
+$ oc apply -f https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/download/$LATEST_RELEASE/openshift.yaml
 $ oc -n dynatrace logs -f deployment/dynatrace-oneagent-operator
 ```
 
@@ -164,13 +166,13 @@ Remove OneAgent custom resources and clean-up all remaining OneAgent Operator sp
 #### Kubernetes
 ```sh
 $ kubectl delete -n dynatrace oneagent --all
-$ kubectl delete -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/kubernetes.yaml
+$ kubectl delete -f https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/download/$LATEST_RELEASE/kubernetes.yaml
 ```
 
 #### OpenShift
 ```sh
 $ oc delete -n dynatrace oneagent --all
-$ oc delete -f https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/master/deploy/openshift.yaml
+$ oc delete -f https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/download/$LATEST_RELEASE/openshift.yaml
 ```
 
 ## Known Limitation


### PR DESCRIPTION
Our Readme instructions were for the development builds, and I have seen occasionally users installing these instead of our stable releases.

With this PR, these are now for installing our stable releases.