### PR TITLE
Add custom property for version by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * The different operator and webhook modes are encapsulated in a single binary ([#252](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/252), [#253](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/253))
 * Webhook's init container only downloads 64bits package ([#256](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/256))
 * Upgrade base image to ubi-minimal:8.2 ([#255](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/255))
+* Include Operator version as a custom property for hosts ([#212](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/212))
 
 ## v0.7
 

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/istio"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/utils"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dtclient"
+	"github.com/Dynatrace/dynatrace-oneagent-operator/version"
 
 	"github.com/go-logr/logr"
 
@@ -418,6 +419,8 @@ func newPodSpecForCR(instance dynatracev1alpha1.BaseOneAgentDaemonSet) corev1.Po
 	if _, ok := instance.(*dynatracev1alpha1.OneAgentIM); ok {
 		args = append(args, "--set-infra-only=true")
 	}
+
+	args = append(args, "--set-host-property=OperatorVersion="+version.Version)
 
 	// K8s 1.18+ is expected to drop the "beta.kubernetes.io" labels in favor of "kubernetes.io" which was added on K8s 1.14.
 	// To support both older and newer K8s versions we use node affinity.

--- a/pkg/controller/oneagent/oneagent_utils_test.go
+++ b/pkg/controller/oneagent/oneagent_utils_test.go
@@ -84,7 +84,7 @@ func TestHasSpecChanged(t *testing.T) {
 	}
 	{
 		ds := newDaemonSetSpec()
-		ds.Template.Spec.Containers[0].Args = []string{"INFRA_ONLY=1"}
+		ds.Template.Spec.Containers[0].Args = []string{"INFRA_ONLY=1", "--set-host-property=OperatorVersion=snapshot"}
 		oa := newOneAgent()
 		oa.Spec.Args = []string{"INFRA_ONLY=1"}
 		exp := &newDaemonSetForCR(oa).Spec
@@ -241,6 +241,9 @@ func newDaemonSetSpec() *appsv1.DaemonSetSpec {
 				Containers: []corev1.Container{
 					{
 						Image: "docker.io/dynatrace/oneagent:latest",
+						Args: []string{
+							"--set-host-property=OperatorVersion=snapshot",
+						},
 						Env: []corev1.EnvVar{
 							{
 								Name: "ONEAGENT_INSTALLER_TOKEN",


### PR DESCRIPTION
With these changes, we're including the Operator version as a host custom property on Operator-managed hosts.

Since the field is supported since OneAgent 1.189, it would show a (benign) error message in earlier versions, but it would still be an error.

I'm creating this PR for review now, and leave the merging until later, a month or so from now perhaps.