### PR TITLE
Refactor Marked for Termination feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Update to Operator SDK 0.15.1 ([#200](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/200))
 * Initial work to ease release automation ([#198](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/198))
 * Added automatic creation of CSV file for OLM ([#210](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/210))
+* Now Marked for Termination events will be sent only for deleted Nodes ([#213](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/213))
 
 ## v0.6
 

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -102,6 +102,15 @@ rules:
       - update
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - "" # "" indicates the core API group
     resources:
       - configmaps
@@ -115,7 +124,6 @@ rules:
   - apiGroups:
       - "" # "" indicates the core API group
     resources:
-      - configmaps
       - pods
     verbs:
       - get

--- a/deploy/kubernetes/role-operator.yaml
+++ b/deploy/kubernetes/role-operator.yaml
@@ -28,6 +28,15 @@ rules:
       - update
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - "" # "" indicates the core API group
     resources:
       - configmaps
@@ -41,7 +50,6 @@ rules:
   - apiGroups:
       - "" # "" indicates the core API group
     resources:
-      - configmaps
       - pods
     verbs:
       - get

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -100,6 +100,15 @@ rules:
       - watch
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - "" # "" indicates the core API group
     resources:
       - secrets

--- a/deploy/openshift/role-operator.yaml
+++ b/deploy/openshift/role-operator.yaml
@@ -48,6 +48,15 @@ rules:
       - watch
       - delete
   - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - "" # "" indicates the core API group
     resources:
       - secrets

--- a/pkg/controller/nodes/cache.go
+++ b/pkg/controller/nodes/cache.go
@@ -1,0 +1,72 @@
+package nodes
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ErrNotFound is returned when entry hasn't been found on the cache.
+var ErrNotFound = errors.New("not found")
+
+// CacheEntry constains information about a Node.
+type CacheEntry struct {
+	Instance  string    `json:"instance"`
+	IPAddress string    `json:"ip"`
+	LastSeen  time.Time `json:"seen"`
+}
+
+// Cache manages information about Nodes.
+type Cache struct {
+	Obj    *corev1.ConfigMap
+	Create bool
+	upd    bool
+}
+
+// Get returns the information about node, or error if not found or failed to unmarshall the data.
+func (c *Cache) Get(node string) (CacheEntry, error) {
+	raw, ok := c.Obj.Data[node]
+	if !ok {
+		return CacheEntry{}, ErrNotFound
+	}
+
+	var out CacheEntry
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return CacheEntry{}, err
+	}
+
+	return out, nil
+}
+
+// Set updates the information about node, or error if failed to marshall the data.
+func (c *Cache) Set(node string, entry CacheEntry) error {
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	c.Obj.Data[node] = string(raw)
+	c.upd = true
+	return nil
+}
+
+// Delete removes the node from the cache.
+func (c *Cache) Delete(node string) {
+	delete(c.Obj.Data, node)
+	c.upd = true
+}
+
+// Keys returns a list of node names on the cache.
+func (c *Cache) Keys() []string {
+	out := make([]string, 0, len(c.Obj.Data))
+	for k := range c.Obj.Data {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Changed returns true if changes have been made to the cache instance.
+func (c *Cache) Changed() bool {
+	return c.Create || c.upd
+}

--- a/pkg/controller/nodes/nodes_controller_test.go
+++ b/pkg/controller/nodes/nodes_controller_test.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -11,186 +12,170 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
+const testNamespace = "dynatrace"
+
+var testCacheKey = client.ObjectKey{Name: cacheName, Namespace: testNamespace}
+
 func init() {
 	apis.AddToScheme(scheme.Scheme) // Register OneAgent and Istio object schemas.
-	os.Setenv(k8sutil.WatchNamespaceEnvVar, "dynatrace")
+	os.Setenv(k8sutil.WatchNamespaceEnvVar, testNamespace)
 }
 
-func TestDetermineCustomResource(t *testing.T) {
-	node := corev1.Node{Spec: corev1.NodeSpec{}}
-	node.Name = "node_1"
-	nodesController := &ReconcileNodes{}
-
-	{
-		oneAgentStatus := dynatracev1alpha1.OneAgentStatus{
-			Instances: map[string]dynatracev1alpha1.OneAgentInstance{},
-		}
-		oneAgent := dynatracev1alpha1.OneAgent{Status: oneAgentStatus}
-		oaList := &dynatracev1alpha1.OneAgentList{
-			Items: []dynatracev1alpha1.OneAgent{oneAgent},
-		}
-
-		res := nodesController.filterOneAgentFromList(oaList, "node_1")
-
-		assert.Nil(t, res)
-	}
-	{
-		oneAgentStatus := dynatracev1alpha1.OneAgentStatus{
-			Instances: map[string]dynatracev1alpha1.OneAgentInstance{
-				"node_1": dynatracev1alpha1.OneAgentInstance{},
+func TestNodesReconciler_CreateCache(t *testing.T) {
+	fakeClient := fake.NewFakeClientWithScheme(
+		scheme.Scheme,
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+		&dynatracev1alpha1.OneAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
+			Status: dynatracev1alpha1.OneAgentStatus{
+				Instances: map[string]dynatracev1alpha1.OneAgentInstance{"node1": {IPAddress: "1.2.3.4"}},
 			},
-		}
-		oneAgent := dynatracev1alpha1.OneAgent{Status: oneAgentStatus}
-		oaList := &dynatracev1alpha1.OneAgentList{
-			Items: []dynatracev1alpha1.OneAgent{oneAgent},
-		}
-
-		res := nodesController.filterOneAgentFromList(oaList, "node_1")
-
-		assert.NotNil(t, res)
-	}
-	{
-		oneAgentStatus := dynatracev1alpha1.OneAgentStatus{
-			Instances: map[string]dynatracev1alpha1.OneAgentInstance{
-				"node_2": dynatracev1alpha1.OneAgentInstance{},
-			},
-		}
-		oneAgent := dynatracev1alpha1.OneAgent{Status: oneAgentStatus}
-		oaList := &dynatracev1alpha1.OneAgentList{
-			Items: []dynatracev1alpha1.OneAgent{oneAgent},
-		}
-
-		res := nodesController.filterOneAgentFromList(oaList, "node_1")
-
-		assert.Nil(t, res)
-
-	}
-	{
-		oneAgentStatus := dynatracev1alpha1.OneAgentStatus{
-			Instances: map[string]dynatracev1alpha1.OneAgentInstance{
-				"node_1": dynatracev1alpha1.OneAgentInstance{},
-				"node_2": dynatracev1alpha1.OneAgentInstance{},
-			},
-		}
-		oneAgent := dynatracev1alpha1.OneAgent{Status: oneAgentStatus}
-		oaList := &dynatracev1alpha1.OneAgentList{
-			Items: []dynatracev1alpha1.OneAgent{oneAgent},
-		}
-
-		res := nodesController.filterOneAgentFromList(oaList, "node_1")
-
-		assert.NotNil(t, res)
-
-	}
-}
-
-func TestNodesReconciler_NewSchedulableNode(t *testing.T) {
-	nodeName := "new-node"
-	fakeClient := fake.NewFakeClient(
-		&corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-		})
-
-	dtClient := &dtclient.MockDynatraceClient{}
-
-	nodesController := NewController(fakeClient, utils.StaticDynatraceClient(dtClient), logf.ZapLoggerTo(os.Stdout, true))
-
-	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
-	assert.Len(t, nodesController.nodeCordonedStatus, 1)
-	assert.Contains(t, nodesController.nodeCordonedStatus, nodeName)
-	assert.False(t, nodesController.nodeCordonedStatus[nodeName])
-	mock.AssertExpectationsForObjects(t, dtClient)
-}
-
-func TestNodesReconciler_UnschedulableNode(t *testing.T) {
-	nodeName := "unschedulable-node"
-	fakeClient := fake.NewFakeClient(
-		&corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-			Spec:       corev1.NodeSpec{Unschedulable: true},
 		},
 		&dynatracev1alpha1.OneAgent{
-			ObjectMeta: metav1.ObjectMeta{Name: "oneagent", Namespace: "dynatrace"},
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent2", Namespace: testNamespace},
 			Status: dynatracev1alpha1.OneAgentStatus{
-				Instances: map[string]dynatracev1alpha1.OneAgentInstance{
-					nodeName: {IPAddress: "1.2.3.4"},
-				},
+				Instances: map[string]dynatracev1alpha1.OneAgentInstance{"node2": {IPAddress: "5.6.7.8"}},
 			},
 		})
 
 	dtClient := &dtclient.MockDynatraceClient{}
+	defer mock.AssertExpectationsForObjects(t, dtClient)
+
+	ctrl := &ReconcileNodes{
+		namespace:    testNamespace,
+		client:       fakeClient,
+		scheme:       scheme.Scheme,
+		logger:       logf.ZapLoggerTo(os.Stdout, true),
+		dtClientFunc: utils.StaticDynatraceClient(dtClient),
+		local:        true,
+	}
+
+	require.NoError(t, ctrl.reconcileAll())
+
+	var cm corev1.ConfigMap
+	require.NoError(t, fakeClient.Get(context.TODO(), testCacheKey, &cm))
+	nodesCache := &Cache{Obj: &cm}
+
+	if info, err := nodesCache.Get("node1"); assert.NoError(t, err) {
+		assert.Equal(t, "1.2.3.4", info.IPAddress)
+		assert.Equal(t, "oneagent1", info.Instance)
+	}
+
+	if info, err := nodesCache.Get("node2"); assert.NoError(t, err) {
+		assert.Equal(t, "5.6.7.8", info.IPAddress)
+		assert.Equal(t, "oneagent2", info.Instance)
+	}
+}
+
+func TestNodesReconciler_DeleteNode(t *testing.T) {
+	fakeClient := fake.NewFakeClientWithScheme(
+		scheme.Scheme,
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+		&dynatracev1alpha1.OneAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
+			Status: dynatracev1alpha1.OneAgentStatus{
+				Instances: map[string]dynatracev1alpha1.OneAgentInstance{"node1": {IPAddress: "1.2.3.4"}},
+			},
+		},
+		&dynatracev1alpha1.OneAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent2", Namespace: testNamespace},
+			Status: dynatracev1alpha1.OneAgentStatus{
+				Instances: map[string]dynatracev1alpha1.OneAgentInstance{"node2": {IPAddress: "5.6.7.8"}},
+			},
+		})
+
+	dtClient := &dtclient.MockDynatraceClient{}
+	defer mock.AssertExpectationsForObjects(t, dtClient)
 	dtClient.On("GetEntityIDForIP", "1.2.3.4").Return("HOST-42", nil)
 	dtClient.On("SendEvent", mock.MatchedBy(func(e *dtclient.EventData) bool {
 		return e.EventType == "MARKED_FOR_TERMINATION"
 	})).Return(nil)
 
-	nodesController := NewController(fakeClient, utils.StaticDynatraceClient(dtClient), logf.ZapLoggerTo(os.Stdout, true))
+	ctrl := &ReconcileNodes{
+		namespace:    testNamespace,
+		client:       fakeClient,
+		scheme:       scheme.Scheme,
+		logger:       logf.ZapLoggerTo(os.Stdout, true),
+		dtClientFunc: utils.StaticDynatraceClient(dtClient),
+		local:        true,
+	}
 
-	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
-	assert.Len(t, nodesController.nodeCordonedStatus, 1)
-	assert.Contains(t, nodesController.nodeCordonedStatus, nodeName)
-	assert.True(t, nodesController.nodeCordonedStatus[nodeName])
-	mock.AssertExpectationsForObjects(t, dtClient)
+	require.NoError(t, ctrl.reconcileAll())
+	require.NoError(t, ctrl.onDeletion("node1"))
+
+	var cm corev1.ConfigMap
+	require.NoError(t, fakeClient.Get(context.TODO(), testCacheKey, &cm))
+	nodesCache := &Cache{Obj: &cm}
+
+	_, err := nodesCache.Get("node1")
+	assert.Equal(t, err, ErrNotFound)
+
+	if info, err := nodesCache.Get("node2"); assert.NoError(t, err) {
+		assert.Equal(t, "5.6.7.8", info.IPAddress)
+		assert.Equal(t, "oneagent2", info.Instance)
+	}
 }
 
-func TestNodesReconciler_DeletedNode(t *testing.T) {
-	nodeName := "deleted-node"
-	fakeClient := fake.NewFakeClient(
-		&corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-			Spec:       corev1.NodeSpec{Unschedulable: true},
+func TestNodesReconciler_NodeNotFound(t *testing.T) {
+	fakeClient := fake.NewFakeClientWithScheme(
+		scheme.Scheme,
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+		&dynatracev1alpha1.OneAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent1", Namespace: testNamespace},
+			Status: dynatracev1alpha1.OneAgentStatus{
+				Instances: map[string]dynatracev1alpha1.OneAgentInstance{"node1": {IPAddress: "1.2.3.4"}},
+			},
 		},
 		&dynatracev1alpha1.OneAgent{
-			ObjectMeta: metav1.ObjectMeta{Name: "oneagent", Namespace: "dynatrace"},
-			Spec:       dynatracev1alpha1.OneAgentSpec{},
+			ObjectMeta: metav1.ObjectMeta{Name: "oneagent2", Namespace: testNamespace},
 			Status: dynatracev1alpha1.OneAgentStatus{
-				Instances: map[string]dynatracev1alpha1.OneAgentInstance{
-					nodeName: {IPAddress: "1.2.3.4"},
-				},
+				Instances: map[string]dynatracev1alpha1.OneAgentInstance{"node2": {IPAddress: "5.6.7.8"}},
 			},
 		})
 
 	dtClient := &dtclient.MockDynatraceClient{}
-	dtClient.On("GetEntityIDForIP", "1.2.3.4").Return("HOST-42", nil)
+	defer mock.AssertExpectationsForObjects(t, dtClient)
+	dtClient.On("GetEntityIDForIP", "5.6.7.8").Return("HOST-84", nil)
 	dtClient.On("SendEvent", mock.MatchedBy(func(e *dtclient.EventData) bool {
 		return e.EventType == "MARKED_FOR_TERMINATION"
 	})).Return(nil)
 
-	nodesController := NewController(fakeClient, utils.StaticDynatraceClient(dtClient), logf.ZapLoggerTo(os.Stdout, true))
+	ctrl := &ReconcileNodes{
+		namespace:    testNamespace,
+		client:       fakeClient,
+		scheme:       scheme.Scheme,
+		logger:       logf.ZapLoggerTo(os.Stdout, true),
+		dtClientFunc: utils.StaticDynatraceClient(dtClient),
+		local:        true,
+	}
 
-	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
-	assert.Len(t, nodesController.nodeCordonedStatus, 1)
-	assert.Contains(t, nodesController.nodeCordonedStatus, nodeName)
-	assert.True(t, nodesController.nodeCordonedStatus[nodeName])
-	mock.AssertExpectationsForObjects(t, dtClient)
-}
+	require.NoError(t, ctrl.reconcileAll())
+	var node2 corev1.Node
+	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: "node2"}, &node2))
+	require.NoError(t, fakeClient.Delete(context.TODO(), &node2))
+	require.NoError(t, ctrl.reconcileAll())
 
-func TestNodesReconciler_UnschedulableNodeAndNoMatchingOneAgent(t *testing.T) {
-	nodeName := "unschedulable-node"
-	fakeClient := fake.NewFakeClient(
-		&corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-			Spec:       corev1.NodeSpec{Unschedulable: true},
-		},
-		&dynatracev1alpha1.OneAgent{
-			ObjectMeta: metav1.ObjectMeta{Name: "oneagent", Namespace: "dynatrace"},
-			Spec: dynatracev1alpha1.OneAgentSpec{
-				NodeSelector: map[string]string{"a": "b"},
-			},
-		})
+	var cm corev1.ConfigMap
+	require.NoError(t, fakeClient.Get(context.TODO(), testCacheKey, &cm))
+	nodesCache := &Cache{Obj: &cm}
 
-	dtClient := &dtclient.MockDynatraceClient{}
+	if info, err := nodesCache.Get("node1"); assert.NoError(t, err) {
+		assert.Equal(t, "1.2.3.4", info.IPAddress)
+		assert.Equal(t, "oneagent1", info.Instance)
+	}
 
-	nodesController := NewController(fakeClient, utils.StaticDynatraceClient(dtClient), logf.ZapLoggerTo(os.Stdout, true))
-
-	assert.NoError(t, nodesController.ReconcileNodes(nodeName))
-	assert.Empty(t, nodesController.nodeCordonedStatus)
-	mock.AssertExpectationsForObjects(t, dtClient)
+	_, err := nodesCache.Get("node2")
+	assert.Equal(t, err, ErrNotFound)
 }

--- a/pkg/controller/nodes/watchers.go
+++ b/pkg/controller/nodes/watchers.go
@@ -1,0 +1,55 @@
+package nodes
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	toolscache "k8s.io/client-go/tools/cache"
+)
+
+// watchDeletions returns a channel where Node deletion operations will be notified.
+func (r *ReconcileNodes) watchDeletions(stop <-chan struct{}) (chan string, error) {
+	ifm, err := r.cache.GetInformer(&corev1.Node{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Don't close this channel and leak it on purpose to avoid panicking if the Informer sends a notification
+	// after we stop, but it's not worth it to have it synchronized.
+	chDels := make(chan string, 20)
+
+	ifm.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) {
+			if o, err := meta.Accessor(obj); err == nil {
+				chDels <- o.GetName()
+			} else {
+				r.logger.Error(err, "missing Meta", "object", obj, "type", fmt.Sprintf("%T", obj))
+			}
+		},
+	})
+
+	return chDels, nil
+}
+
+// watchTicks returns a channel where tick messages will be sent periodically.
+//
+// Unlike time.Ticker, this function will also send an initial tick.
+func watchTicks(stop <-chan struct{}, d time.Duration) <-chan struct{} {
+	chAll := make(chan struct{}, 1)
+	chAll <- struct{}{}
+
+	go func() {
+		defer close(chAll)
+
+		ticker := time.NewTicker(d)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			chAll <- struct{}{}
+		}
+	}()
+
+	return chAll
+}


### PR DESCRIPTION
On this PR I'm refactoring when Marked for Termination events are going to be sent: rather than sending them when a node goes cordoned or deleted, we'll now only send them when deleted.

The reason is that a node being cordoned doesn't affect DaemonSets such as the OneAgent; they are still running, so the timings can be wrong.

So the idea here is to keep a cache of seen nodes in a ConfigMap on the dynatrace namespace (called it `dynatrace-node-cache`. I've modified the Nodes controller to run periodically every 5 minutes to check the current state and send events if a node on the cache doesn't exist anymore. I've also added the logic to recognize deletions from the Dynatrace API.

As for additional notes,
* The usual Controller pattern from the the controller-runtime doesn't fit our purposes, so the Node Controller is now a "Runnable".
* The cache ConfigMap is owned by the Operator Deployment, so will be removed on uninstallations, etc.
  * And to set this ownership, I need to query for ReplicaSet and Deployment objects, so I've added the permissions to the Roles.
* In case of failures, unlike the standard Controller logic, I'm just logging the error and will try again on the next full reconciliation (so in 5 minutes.)