### PR TITLE
Fixes for Mark for Termination refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Update to Operator SDK 0.15.1 ([#200](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/200))
 * Initial work to ease release automation ([#198](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/198))
 * Added automatic creation of CSV file for OLM ([#210](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/210))
-* Now Marked for Termination events will be sent only for deleted Nodes ([#213](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/213))
+* Now Marked for Termination events will be sent only for deleted Nodes ([#213](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/213), [#214](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/214))
 
 ## v0.6
 

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -111,6 +111,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - "" # "" indicates the core API group
     resources:
       - configmaps

--- a/deploy/kubernetes/role-operator.yaml
+++ b/deploy/kubernetes/role-operator.yaml
@@ -37,6 +37,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - "" # "" indicates the core API group
     resources:
       - configmaps

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -109,6 +109,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - "" # "" indicates the core API group
     resources:
       - secrets

--- a/deploy/openshift/role-operator.yaml
+++ b/deploy/openshift/role-operator.yaml
@@ -57,6 +57,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
       - "" # "" indicates the core API group
     resources:
       - secrets

--- a/pkg/controller/nodes/cache.go
+++ b/pkg/controller/nodes/cache.go
@@ -27,6 +27,10 @@ type Cache struct {
 
 // Get returns the information about node, or error if not found or failed to unmarshall the data.
 func (c *Cache) Get(node string) (CacheEntry, error) {
+	if c.Obj.Data == nil {
+		return CacheEntry{}, ErrNotFound
+	}
+
 	raw, ok := c.Obj.Data[node]
 	if !ok {
 		return CacheEntry{}, ErrNotFound
@@ -46,6 +50,9 @@ func (c *Cache) Set(node string, entry CacheEntry) error {
 	if err != nil {
 		return err
 	}
+	if c.Obj.Data == nil {
+		c.Obj.Data = map[string]string{}
+	}
 	c.Obj.Data[node] = string(raw)
 	c.upd = true
 	return nil
@@ -53,12 +60,18 @@ func (c *Cache) Set(node string, entry CacheEntry) error {
 
 // Delete removes the node from the cache.
 func (c *Cache) Delete(node string) {
-	delete(c.Obj.Data, node)
-	c.upd = true
+	if c.Obj.Data != nil {
+		delete(c.Obj.Data, node)
+		c.upd = true
+	}
 }
 
 // Keys returns a list of node names on the cache.
 func (c *Cache) Keys() []string {
+	if c.Obj.Data == nil {
+		return []string{}
+	}
+
 	out := make([]string, 0, len(c.Obj.Data))
 	for k := range c.Obj.Data {
 		out = append(out, k)


### PR DESCRIPTION
Some fixes:
* OCP 3.11 seems to require additional permissions to set the owner.
* When querying the cache ConfigMap and there are no entries, you'd get a nil "data" field.
* There may be a delay before an entry is removed from the OneAgent object. On the Nodes Controller, nonexistent nodes are ignored when preparing the cache.