### PR TITLE
Use v1 for RBAC objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Initial work to ease release automation ([#198](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/198))
 * Added automatic creation of CSV file for OLM ([#210](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/210))
 * Now Marked for Termination events will be sent only for deleted Nodes ([#213](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/213), [#214](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/214))
+* Use `v1` instead of `v1beta1` for `rbac.authorization.k8s.io` objects ([#215](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/215))
 
 ## v0.6
 

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -72,7 +72,7 @@ spec:
   fsGroup:
     rule: "RunAsAny"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: dynatrace-oneagent-operator
@@ -193,7 +193,7 @@ rules:
     verbs:
       - use
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: dynatrace-oneagent-operator
@@ -622,7 +622,7 @@ spec:
                       - linux
       serviceAccountName: dynatrace-oneagent-operator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dynatrace-oneagent-operator
@@ -639,7 +639,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/kubernetes/clusterrole.yaml
+++ b/deploy/kubernetes/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/kubernetes/clusterrolebinding.yaml
+++ b/deploy/kubernetes/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/kubernetes/role-operator.yaml
+++ b/deploy/kubernetes/role-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/kubernetes/rolebinding-operator.yaml
+++ b/deploy/kubernetes/rolebinding-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -50,7 +50,7 @@ users:
 volumes:
   - "*"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: dynatrace-oneagent-operator
@@ -148,7 +148,7 @@ rules:
       - update
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: dynatrace-oneagent-operator
@@ -563,7 +563,7 @@ spec:
                       - linux
       serviceAccountName: dynatrace-oneagent-operator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dynatrace-oneagent-operator
@@ -580,7 +580,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/openshift/clusterrole.yaml
+++ b/deploy/openshift/clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/openshift/clusterrolebinding.yaml
+++ b/deploy/openshift/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/openshift/role-operator.yaml
+++ b/deploy/openshift/role-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: dynatrace-oneagent-operator

--- a/deploy/openshift/rolebinding-operator.yaml
+++ b/deploy/openshift/rolebinding-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: dynatrace-oneagent-operator


### PR DESCRIPTION
The `v1beta1` version for the RBAC objects was replaced by `v1` on Kubernetes 1.8.

It seems Kubernetes is converting them to the new version automatically, but we can update our manifests anyway.