### PR TITLE
Add handling for reaching the Dynatrace API quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * No longer change the OneAgent .spec section to set defaults ([#206](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/206))
 * Added a setting to configure a proxy via the CR ([#207](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/207))
 * Added a setting to add custom CA certificates via the CR - This changes are only done for the Operator image as of now and the changes in the OneAgent image are in progress ([#208](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/208))
+* Added proper error handling for Dynatrace API quota limit ([#216](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/216))
 
 ### Bug fixes
 * Handle sporadic (and benign) race conditions where the error below would appear ([#194](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/194)),

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -217,6 +217,7 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 			logger.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
+		return reconcile.Result{}, err
 	}
 
 	// finally we have to determine the correct non error phase

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -187,6 +187,7 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 			logger.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
+		reconcile.Result{}, err
 	}
 
 	if instance.Spec.DisableAgentUpdate {

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -187,7 +187,7 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 			logger.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
 			return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
-		reconcile.Result{}, err
+		return reconcile.Result{}, err
 	}
 
 	if instance.Spec.DisableAgentUpdate {

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -172,6 +172,11 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, errClient
 		}
 		if err != nil {
+			var serr dtclient.ServerError
+			if ok := errors.As(err, &serr); ok && serr.Code == http.StatusTooManyRequests {
+				logger.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
+				return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
+			}
 			return reconcile.Result{}, err
 		}
 
@@ -194,7 +199,7 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 			var serr dtclient.ServerError
 			if ok := errors.As(err, &serr); ok && serr.Code == http.StatusTooManyRequests {
 				logger.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
-				return reconcile.Result{RequeueAfter: 1 * time.Minute}, err
+				return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 			}
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -191,6 +191,11 @@ func (r *ReconcileOneAgent) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, errClient
 		}
 		if err != nil {
+			var serr dtclient.ServerError
+			if ok := errors.As(err, &serr); ok && serr.Code == http.StatusTooManyRequests {
+				logger.Info("Request limit for Dynatrace API reached! Next reconcile in one minute")
+				return reconcile.Result{RequeueAfter: 1 * time.Minute}, err
+			}
 			return reconcile.Result{}, err
 		}
 

--- a/pkg/controller/oneagent/oneagent_utils_test.go
+++ b/pkg/controller/oneagent/oneagent_utils_test.go
@@ -183,11 +183,12 @@ func TestGetPodsToRestart(t *testing.T) {
 	oa := newOneAgent()
 	oa.Status.Version = "1.2.3"
 	oa.Status.Instances = map[string]api.OneAgentInstance{"node-3": {Version: "outdated"}}
-	doomed, instances := getPodsToRestart(pods, dtc, oa)
+	doomed, instances, err := getPodsToRestart(pods, dtc, oa)
 	assert.Lenf(t, doomed, 1, "list of pods to restart")
 	assert.Equalf(t, doomed[0], pods[1], "list of pods to restart")
 	assert.Lenf(t, instances, 3, "list of instances")
 	assert.Equalf(t, instances["node-3"].Version, oa.Status.Instances["node-3"].Version, "determine agent version from dynatrace server")
+	assert.Equal(t, nil, err)
 }
 
 func TestNotifyDynatraceAboutMarkForTerminationEvent(t *testing.T) {

--- a/pkg/dtclient/dynatrace_client.go
+++ b/pkg/dtclient/dynatrace_client.go
@@ -90,8 +90,7 @@ func (dc *dynatraceClient) getHostInfoForIP(ip string) (*hostInfo, error) {
 	if len(dc.hostCache) == 0 {
 		err := dc.buildHostCache()
 		if err != nil {
-			logger.Error(err, "error building hostcache from dynatrace cluster")
-			return nil, err
+			return nil, fmt.Errorf("error building hostcache from dynatrace cluster: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Due to our limitation for a max of 50 requests per minute to our Dynatrace API our Operator sometimes displayed error messages.
Implemented proper error handling and added a reconciliation interval of 1 minute in this case.