### PR TITLE
Add ownership to Istio objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   Operation cannot be fulfilled on oneagents.dynatrace.com \"oneagent\": the object has been modified; please apply your changes to the latest version and try again
   ```
 * Proxy environment variables (e.g., `http_proxy`, etc.) can be ignored on Operator container when `skipCertCheck` is true ([#204](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/204))
+* Istio objects don't have an owner object, so wouldn't get removed if the OneAgent object is deleted ([#217](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/217))
 
 ### Other changes
 * As part of the support for ARM ([#201](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/201), [#203](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/203))

--- a/pkg/integrationtests/envutils_test.go
+++ b/pkg/integrationtests/envutils_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/oneagent"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/utils"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/dtclient"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,6 +91,7 @@ var testEnvironmentCRDs = []*apiextensionsv1beta1.CustomResourceDefinition{
 func init() {
 	// Register OneAgent and Istio object schemas.
 	apis.AddToScheme(scheme.Scheme)
+	os.Setenv(k8sutil.WatchNamespaceEnvVar, DefaultTestNamespace)
 }
 
 type ControllerTestEnvironment struct {


### PR DESCRIPTION
I'm adding the owner to Istio objects, so in case the corresponding OneAgent gets deleted, the generated Istio objects get deleted as well.

Additionally,
* ReconcileIstio returns (bool, error) now. We weren't doing anything with the extra boolean.
* Reduced the waiting time if ReconcileIstio succeeds. It exists only to give some time for Istio to recognize the extra ServiceEntry and VirtualService objects. 1min is perhaps overkill.