### PR TITLE
Workaround for unready informer in Nodes controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * Update to Operator SDK 0.15.1 ([#200](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/200))
 * Initial work to ease release automation ([#198](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/198))
 * Added automatic creation of CSV file for OLM ([#210](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/210))
-* Now Marked for Termination events will be sent only for deleted Nodes ([#213](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/213), [#214](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/214))
+* Now Marked for Termination events will be sent only for deleted Nodes ([#213](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/213), [#214](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/214), [#223](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/223))
 * Use `v1` instead of `v1beta1` for `rbac.authorization.k8s.io` objects ([#215](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/215))
 
 ## v0.6

--- a/pkg/controller/nodes/nodes_controller.go
+++ b/pkg/controller/nodes/nodes_controller.go
@@ -59,7 +59,13 @@ func (r *ReconcileNodes) Start(stop <-chan struct{}) error {
 
 	chDels, err := r.watchDeletions(stop)
 	if err != nil {
-		return err
+		// I've seen watchDeletions() fail because the Cache Informers weren't ready. WaitForCacheSync()
+		// should block until they are, however, but I believe I saw this not being true once.
+		//
+		// Start() failing would exit the Operator process. Since this is a minor feature, let's disable
+		// for now until further investigation is done.
+		r.logger.Info("failed to initialize watcher for deleted nodes - disabled", "error", err)
+		chDels = make(chan string)
 	}
 
 	chAll := watchTicks(stop, 5*time.Minute)


### PR DESCRIPTION
I saw the case of an error message on the Nodes Controller where the Informers is not ready. This shouldn't happen, but just in case, when the watcher for deletions fail, here I'm ignoring the error and continuing so that the Operator doesn't exit.

Deletions will be seen in the periodic check every five minutes however, so the feature most likely will work anyway.