### PR TITLE
Send Marked for Termination as a point in time event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 ### Bug fixes
+* Marked for Termination events are not a point in time instead of a time range of a few minutes ([#229](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/229))
 
 ### Other changes
 * Added environment variable 'RELATED_IMAGE_DYNATRACE_ONEAGENT' as preparation for RedHat marketplace release ([#228](hhttps://github.com/Dynatrace/dynatrace-oneagent-operator/pull/228))

--- a/pkg/controller/nodes/nodes_controller.go
+++ b/pkg/controller/nodes/nodes_controller.go
@@ -271,11 +271,13 @@ func (r *ReconcileNodes) sendMarkedForTermination(oa *dynatracev1alpha1.OneAgent
 		return err
 	}
 
+	ts := uint64(lastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond)
 	return dtc.SendEvent(&dtclient.EventData{
 		EventType:     dtclient.MarkedForTerminationEvent,
 		Source:        "OneAgent Operator",
 		Description:   "Kubernetes node cordoned. Node might be drained or terminated.",
-		StartInMillis: uint64(lastSeen.Add(-10*time.Minute).UnixNano()) / uint64(time.Millisecond),
+		StartInMillis: ts,
+		EndInMillis:   ts,
 		AttachRules: dtclient.EventDataAttachRules{
 			EntityIDs: []string{entityID},
 		},

--- a/pkg/dtclient/send_event.go
+++ b/pkg/dtclient/send_event.go
@@ -16,6 +16,7 @@ const (
 type EventData struct {
 	EventType     string               `json:"eventType"`
 	StartInMillis uint64               `json:"start"`
+	EndInMillis   uint64               `json:"end"`
 	Description   string               `json:"description"`
 	AttachRules   EventDataAttachRules `json:"attachRules"`
 	Source        string               `json:"source"`

--- a/pkg/dtclient/send_event_test.go
+++ b/pkg/dtclient/send_event_test.go
@@ -12,6 +12,7 @@ func TestEventDataMarshal(t *testing.T) {
 	testJSONInput := []byte(`{
 		"eventType": "MARKED_FOR_TERMINATION",
 		"start": 20,
+		"end": 20,
 		"description": "K8s node was marked unschedulable. Node is likely being drained",
 		"attachRules": {
 			"entityIds": [ "HOST-CA78D78BBC6687D3" ]
@@ -36,6 +37,7 @@ func testSendEvent(t *testing.T, dynatraceClient Client) {
 		testValidEventData := []byte(`{
 			"eventType": "MARKED_FOR_TERMINATION",
 			"start": 20,
+			"end": 20,
 			"description": "K8s node was marked unschedulable. Node is likely being drained",
 			"attachRules": {
 				"entityIds": [ "HOST-CA78D78BBC6687D3" ]
@@ -52,6 +54,7 @@ func testSendEvent(t *testing.T, dynatraceClient Client) {
 	{
 		testInvalidEventData := []byte(`{
 			"start": 20,
+			"end": 20,
 			"description": "K8s node was marked unschedulable. Node is likely being drained",
 			"attachRules": {
 				"entityIds": [ "HOST-CA78D78BBC6687D3" ]
@@ -69,6 +72,7 @@ func testSendEvent(t *testing.T, dynatraceClient Client) {
 		testExtraKeysEventData := []byte(`{
 			"eventType": "MARKED_FOR_TERMINATION",
 			"start": 20,
+			"end": 20,
 			"description": "K8s node was marked unschedulable. Node is likely being drained",
 			"attachRules": {
 				"entityIds": [ "HOST-CA78D78BBC6687D3" ]


### PR DESCRIPTION
We were not setting the end time for the Marked for Termination event, making it to take the sending time as end time, which then made the event last like 10 mins.

This PR changes it to be a point in time instead.