### PR TITLE
Add SecurityContext to webhook's init container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Future
 
 #### Features
-* Implement webhook to inject the OneAgent in App-only mode ([#234](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/234), [#237](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/237))
+* Implement webhook to inject the OneAgent in App-only mode ([#234](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/234), [#237](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/237), [#239](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/239))
   * This feature can be enabled by setting the label `oneagent.dynatrace.com/instance: <oneagent-object-name>` on the namespaces to monitor.
 
 ## v0.7

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -131,6 +131,11 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 			},
 		})
 
+	var sc *corev1.SecurityContext
+	if pod.Spec.Containers[0].SecurityContext != nil {
+		sc = pod.Spec.Containers[0].SecurityContext.DeepCopy()
+	}
+
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 		Name:    "install-oneagent",
 		Image:   m.image,
@@ -152,6 +157,7 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 				},
 			},
 		},
+		SecurityContext: sc,
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "oneagent", MountPath: dtwebhook.PathOneAgentDir},
 			{Name: "oneagent-config", MountPath: "/mnt/config"},


### PR DESCRIPTION
OpenShift is strict regarding containers' SecurityContext settings. OpenShift will modify Pods to include default settings for SecurityContext, before going through our webhook, so _we need to add those settings ourselves_. In particular we need RunAsUser, otherwise it won't pass the `restricted` SecurityContextConstraint and pod injected won't be deployed (again, if using this SCC.) To my understanding this is also a problem with Kubernetes if PodSecurityPolicies are enabled.

This problem seems to be solved after Kubernetes 1.15/OCP 4.3, where OCP webhooks would be applied again if there are changes.

As a workaround, I'm copying the SecurityContext of the first container to the init container.

There is some discussion here, https://github.com/openshift/origin/issues/20543, for the issue and, https://github.com/kubeflow/katib/pull/964, where people solved it by copying it.