### PR TITLE
Renew webhook certificates automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features
 * Implement webhook to inject the OneAgent in App-only mode ([#234](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/234), [#237](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/237), [#239](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/239))
   * This feature can be enabled by setting the label `oneagent.dynatrace.com/instance: <oneagent-object-name>` on the namespaces to monitor.
+  * CA and server certificates are generated for the webhook by the Operator, and renewed automatically after 365 and 7 days, respectively ([#244](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/244))
 
 ### Other changes
 * Removed kubernetes.yaml and openshift.yaml from master and generate them with kustomize instead ([#238](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/238))

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,7 @@ ENV BIN_DIR=/usr/local/bin/dynatrace/oneagent \
     USER_UID=1001 \
     USER_NAME=dynatrace-oneagent-operator
 
-RUN  microdnf install openssl unzip && microdnf clean all
+RUN  microdnf install unzip && microdnf clean all
 COPY LICENSE /licenses/
 COPY build/_output/bin ${BIN_DIR}
 COPY build/bin /usr/local/bin

--- a/deploy/common/role-webhook.yaml
+++ b/deploy/common/role-webhook.yaml
@@ -12,6 +12,7 @@ rules:
     resources:
       - services
       - configmaps
+      - secrets
     verbs:
       - get
       - list

--- a/pkg/webhook/bootstrapper/certs.go
+++ b/pkg/webhook/bootstrapper/certs.go
@@ -1,95 +1,229 @@
 package bootstrapper
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
-	"os/exec"
-	"path"
+	"time"
+
+	"github.com/go-logr/logr"
 )
 
 var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
-type certs struct {
-	rootPublicCertPEM []byte
+const renewalThreshold = 4 * time.Hour
+
+// Certs handles creation and renewal of CA and SSL/TLS server certificates.
+type Certs struct {
+	Log     logr.Logger
+	Domain  string
+	SrcData map[string][]byte
+	Data    map[string][]byte
+
+	now time.Time
+
+	rootPrivateKey *rsa.PrivateKey
+	rootPublicCert *x509.Certificate
 }
 
-func (cs *certs) generateRootCerts(dir, domain string) error {
-	var err error
-
-	keyPath := path.Join(dir, "ca.key")
-	certPath := path.Join(dir, "ca.crt")
-
-	if out, err := exec.Command(
-		"openssl",
-		"genrsa",
-		"-out", keyPath,
-		"4096").CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to generate root key: %v: %s", err, out)
+// ValidateCerts checks for certificates and keys on cs.SrcData and renews them if needed. The existing (or new)
+// certificates will be stored on cs.Data.
+func (cs *Certs) ValidateCerts() error {
+	cs.Data = map[string][]byte{}
+	if cs.SrcData != nil {
+		for k, v := range cs.SrcData {
+			cs.Data[k] = v
+		}
 	}
 
-	if out, err := exec.Command(
-		"openssl",
-		"req",
-		"-x509",
-		"-new",
-		"-nodes",
-		"-key", keyPath,
-		"-sha256",
-		"-days", "365",
-		"-out", certPath,
-		"-subj", "/C=AT/ST=UA/L=Linz/O=Dynatrace/OU=CloudPlatform/CN="+domain).CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to generate root certificate: %v: %s", err, out)
+	now := time.Now().UTC()
+	if !cs.now.IsZero() {
+		now = cs.now
 	}
 
-	cs.rootPublicCertPEM, err = ioutil.ReadFile(certPath)
-	if err != nil {
-		return fmt.Errorf("failed to read root certificate: %w", err)
+	renewRootCerts := cs.validateRootCerts(now)
+	if renewRootCerts {
+		if err := cs.generateRootCerts(cs.Domain, now); err != nil {
+			return err
+		}
+	}
+
+	if renewRootCerts || cs.validateServerCerts(now) {
+		return cs.generateServerCerts(cs.Domain, now)
 	}
 
 	return nil
 }
 
-func (cs *certs) generateServerCerts(dir, domain string) error {
-	caKeyPath := path.Join(dir, "ca.key")
-	caCertPath := path.Join(dir, "ca.crt")
-	csrPath := path.Join(dir, "tls.csr")
-	keyPath := path.Join(dir, "tls.key")
-	certPath := path.Join(dir, "tls.crt")
-
-	if out, err := exec.Command(
-		"openssl",
-		"genrsa",
-		"-out", keyPath,
-		"4096").CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to generate server key: %v: %s", err, out)
+func (cs *Certs) validateRootCerts(now time.Time) bool {
+	if cs.Data["ca.key"] == nil || cs.Data["ca.crt"] == nil {
+		cs.Log.Info("No root certificates found, creating")
+		return true
 	}
 
-	if out, err := exec.Command(
-		"openssl",
-		"req",
-		"-new",
-		"-nodes",
-		"-key", keyPath,
-		"-sha256",
-		"-out", csrPath,
-		"-subj", "/C=AT/ST=UA/L=Linz/O=Dynatrace/OU=CloudPlatform/CN="+domain).CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to generate server certificate signing request: %v: %s", err, out)
+	var err error
+
+	if block, _ := pem.Decode(cs.Data["ca.crt"]); block == nil {
+		cs.Log.Info("Failed to parse root certificates, renewing", "error", "can't decode PEM file")
+		return true
+	} else if cs.rootPublicCert, err = x509.ParseCertificate(block.Bytes); err != nil {
+		cs.Log.Info("Failed to parse root certificates, renewing", "error", err)
+		return true
+	} else if now.After(cs.rootPublicCert.NotAfter.Add(-renewalThreshold)) {
+		cs.Log.Info("Root certificates are about to expire, renewing", "current", now, "expiration", cs.rootPublicCert.NotAfter)
+		return true
 	}
 
-	if out, err := exec.Command(
-		"openssl",
-		"x509",
-		"-req",
-		"-in", csrPath,
-		"-CA", caCertPath,
-		"-CAkey", caKeyPath,
-		"-CAcreateserial",
-		"-out", certPath,
-		"-days", "7",
-		"-sha256").CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to generate server certificate: %v: %s", err, out)
+	if block, _ := pem.Decode(cs.Data["ca.key"]); block == nil {
+		cs.Log.Info("Failed to parse root key, renewing", "error", "can't decode PEM file")
+		return true
+	} else if cs.rootPrivateKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+		cs.Log.Info("Failed to parse root key, renewing", "error", err)
+		return true
 	}
 
+	return false
+}
+
+func (cs *Certs) validateServerCerts(now time.Time) bool {
+	if cs.Data["tls.key"] == nil || cs.Data["tls.crt"] == nil {
+		cs.Log.Info("No server certificates found, creating")
+		return true
+	}
+
+	block, _ := pem.Decode(cs.Data["tls.crt"])
+	if block == nil {
+		cs.Log.Info("Failed to parse server certificates, renewing", "error", "can't decode PEM file")
+		return true
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		cs.Log.Info("Failed to parse server certificates, renewing", "error", err)
+		return true
+	}
+
+	if now.After(cert.NotAfter.Add(-renewalThreshold)) {
+		cs.Log.Info("Server certificates are about to expire, renewing", "current", now, "expiration", cert.NotAfter)
+		return true
+	}
+
+	return false
+}
+
+func (cs *Certs) generateRootCerts(domain string, now time.Time) error {
+	var err error
+
+	// Generate CA root keys
+
+	if cs.rootPrivateKey, err = rsa.GenerateKey(rand.Reader, 4096); err != nil {
+		return fmt.Errorf("failed to generate root private key: %w", err)
+	}
+
+	if err = cs.rootPrivateKey.Validate(); err != nil {
+		return fmt.Errorf("validation for root private key failed: %w", err)
+	}
+
+	cs.Data["ca.key"] = pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(cs.rootPrivateKey),
+	})
+
+	// Generate CA root certificate
+
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return fmt.Errorf("failed to generate serial number for root certificate: %w", err)
+	}
+
+	cs.rootPublicCert = &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Country:            []string{"AT"},
+			Province:           []string{"UA"},
+			Locality:           []string{"Linz"},
+			Organization:       []string{"Dynatrace"},
+			OrganizationalUnit: []string{"CloudPlatform"},
+			CommonName:         domain,
+		},
+		IsCA: true,
+
+		NotBefore: now,
+		NotAfter:  now.Add(365 * 24 * time.Hour),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	rootPublicCertDER, err := x509.CreateCertificate(
+		rand.Reader,
+		cs.rootPublicCert,
+		cs.rootPublicCert,
+		cs.rootPrivateKey.Public(),
+		cs.rootPrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to generate root certificate: %w", err)
+	}
+
+	cs.Data["ca.crt"] = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootPublicCertDER})
+	return nil
+}
+
+func (cs *Certs) generateServerCerts(domain string, now time.Time) error {
+	// Generate server keys
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return fmt.Errorf("failed to generate server private key: %w", err)
+	}
+
+	if err = privKey.Validate(); err != nil {
+		return fmt.Errorf("validation for server private key failed: %w", err)
+	}
+
+	cs.Data["tls.key"] = pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+	})
+
+	// Generate server certificate
+
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return fmt.Errorf("failed to generate serial number for server certificate: %w", err)
+	}
+
+	tpl := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Country:            []string{"AT"},
+			Province:           []string{"UA"},
+			Locality:           []string{"Linz"},
+			Organization:       []string{"Dynatrace"},
+			OrganizationalUnit: []string{"CloudPlatform"},
+			CommonName:         domain,
+		},
+
+		DNSNames: []string{domain},
+
+		NotBefore: now,
+		NotAfter:  now.Add(7 * 24 * time.Hour),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	serverPublicCertDER, err := x509.CreateCertificate(rand.Reader, tpl, cs.rootPublicCert, privKey.Public(), cs.rootPrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to generate server certificate: %w", err)
+	}
+
+	cs.Data["tls.crt"] = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverPublicCertDER})
 	return nil
 }

--- a/pkg/webhook/bootstrapper/certs_test.go
+++ b/pkg/webhook/bootstrapper/certs_test.go
@@ -1,0 +1,80 @@
+package bootstrapper
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestCertsValidation(t *testing.T) {
+	logger := logf.ZapLoggerTo(os.Stdout, true)
+
+	now, _ := time.Parse(time.RFC3339, "2018-01-10T00:00:00Z")
+	domain := "dynatrace-oneagent-webhook.webhook.svc"
+	firstCerts := Certs{Log: logger, Domain: domain, now: now}
+
+	require.NoError(t, firstCerts.ValidateCerts())
+	require.Equal(t, len(firstCerts.Data), 4)
+	requireValidCerts(t, domain, now.Add(5*time.Minute), firstCerts.Data["ca.crt"], firstCerts.Data["tls.crt"])
+
+	t.Run("up-to-date certs", func(t *testing.T) {
+		newTime := now.Add(5 * time.Minute)
+
+		newCerts := Certs{Log: logger, Domain: domain, SrcData: firstCerts.Data, now: newTime}
+		require.NoError(t, newCerts.ValidateCerts())
+		requireValidCerts(t, domain, newTime, newCerts.Data["ca.crt"], newCerts.Data["tls.crt"])
+
+		// No changes should have been applied.
+		assert.Equal(t, string(firstCerts.Data["ca.crt"]), string(newCerts.Data["ca.crt"]))
+		assert.Equal(t, string(firstCerts.Data["ca.key"]), string(newCerts.Data["ca.key"]))
+		assert.Equal(t, string(firstCerts.Data["tls.crt"]), string(newCerts.Data["tls.crt"]))
+		assert.Equal(t, string(firstCerts.Data["tls.key"]), string(newCerts.Data["tls.key"]))
+	})
+
+	t.Run("outdated server certs", func(t *testing.T) {
+		newTime := now.Add((6*24 + 22) * time.Hour) // 6d22h
+
+		newCerts := Certs{Log: logger, Domain: domain, SrcData: firstCerts.Data, now: newTime}
+		require.NoError(t, newCerts.ValidateCerts())
+		requireValidCerts(t, domain, newTime, newCerts.Data["ca.crt"], newCerts.Data["tls.crt"])
+
+		// Server certificates should have been updated.
+		assert.Equal(t, string(firstCerts.Data["ca.crt"]), string(newCerts.Data["ca.crt"]))
+		assert.Equal(t, string(firstCerts.Data["ca.key"]), string(newCerts.Data["ca.key"]))
+		assert.NotEqual(t, string(firstCerts.Data["tls.crt"]), string(newCerts.Data["tls.crt"]))
+		assert.NotEqual(t, string(firstCerts.Data["tls.key"]), string(newCerts.Data["tls.key"]))
+	})
+
+	t.Run("outdated root certs", func(t *testing.T) {
+		newTime := now.Add((364*24 + 22) * time.Hour) // 364d22h
+
+		newCerts := Certs{Log: logger, Domain: domain, SrcData: firstCerts.Data, now: newTime}
+		require.NoError(t, newCerts.ValidateCerts())
+		requireValidCerts(t, domain, newTime, newCerts.Data["ca.crt"], newCerts.Data["tls.crt"])
+
+		// Server certificates should have been updated.
+		assert.NotEqual(t, string(firstCerts.Data["ca.crt"]), string(newCerts.Data["ca.crt"]))
+		assert.NotEqual(t, string(firstCerts.Data["ca.key"]), string(newCerts.Data["ca.key"]))
+		assert.NotEqual(t, string(firstCerts.Data["tls.crt"]), string(newCerts.Data["tls.crt"]))
+		assert.NotEqual(t, string(firstCerts.Data["tls.key"]), string(newCerts.Data["tls.key"]))
+	})
+}
+
+func requireValidCerts(t *testing.T, domain string, now time.Time, caCert, tlsCert []byte) {
+	caCerts := x509.NewCertPool()
+	require.True(t, caCerts.AppendCertsFromPEM(caCert))
+
+	block, _ := pem.Decode(tlsCert)
+	require.NotNil(t, block)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	_, err = cert.Verify(x509.VerifyOptions{DNSName: domain, CurrentTime: now, Roots: caCerts})
+	require.NoError(t, err)
+}

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -25,8 +25,11 @@ const (
 	// PathOneAgentProcessAgent points to where the Process Agent will reside.
 	PathOneAgentProcessAgent = PathOneAgentDir + "/agent/lib64/liboneagentproc.so"
 
-	// SecretConfig is the name of the secret where the Operator replicates the config data.
+	// SecretConfigName is the name of the secret where the Operator replicates the config data.
 	SecretConfigName = "dynatrace-oneagent-config"
+
+	// SecretCertsName is the name of the secret where the webhook certificates are stored.
+	SecretCertsName = "dynatrace-oneagent-webhook-certs"
 
 	// ServiceName is the name used for the webhook's corresponding Service and MutatingWebhookConfiguration objects.
 	ServiceName = "dynatrace-oneagent-webhook"


### PR DESCRIPTION
With this PR the webhook bootstrapper renews automatically the certificates used by the webhook:
* I've moved the certificate generation from the OpenSSL CLI to the Go standard library.
* CA certificates are configured to last for 365 days, and will be renewed 4 hours before the expiration.
* Server certificates are configured to last for 7 days, and will also be renewed 4 hours before the expiration.
* The generated certificates are stored in a secret `dynatrace-oneagent-webhook-certs` on the Operator namespace, and will be reused if you restart the webhook Pod.
* You can force the regeneration of certificates by deleting this secret as well. The webhook bootstrapper will check and every five minutes.