### PR TITLE
Set Operator-SDK version to 0.15.2 instead of using latest

### DIFF
--- a/build/prepare_csv.sh
+++ b/build/prepare_csv.sh
@@ -5,14 +5,14 @@ set -eu
 VERSION=$(echo $TRAVIS_TAG | sed 's/v//')
 
 # Get the latest operator-sdk
+OPERATOR_SDK_VERSION="v0.15.2"
 OPERATOR_SDK="/usr/local/bin/operator-sdk"
 
 if [ ! -f "/usr/local/bin/operator-sdk" ]; then
-    LATEST_OPERATOR_SDK_RELEASE=$(curl -s https://api.github.com/repos/operator-framework/operator-sdk/releases/latest | grep tag_name | cut -d '"' -f 4)
-    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${LATEST_OPERATOR_SDK_RELEASE}/operator-sdk-${LATEST_OPERATOR_SDK_RELEASE}-x86_64-linux-gnu
-    chmod +x operator-sdk-${LATEST_OPERATOR_SDK_RELEASE}-x86_64-linux-gnu
+    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
+    chmod +x operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
     sudo mkdir -p /usr/local/bin/
-    sudo mv operator-sdk-${LATEST_OPERATOR_SDK_RELEASE}-x86_64-linux-gnu /usr/local/bin/operator-sdk
+    sudo mv operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk
 fi
 
 LATEST_OPERATOR_RELEASE=$(ls -d ./deploy/olm/kubernetes/*/ | sort -r | head -n 1 | xargs -n 1 basename)


### PR DESCRIPTION
Since the new way of generating the CSV file does not really work for us we use a specific version of the Operator-SDK (0.15.2).

Once they fixed the generation so we can use it we can think of updating the version.
Moved it to a variable so changing it afterwards is easier