### PR TITLE
Ignore hosts without OneAgent version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Webhook's init container only downloads 64bits package ([#256](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/256))
 * Upgrade base image to ubi-minimal:8.2 ([#255](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/255))
 * Include Operator version as a custom property for hosts ([#212](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/212))
+* Ignore hosts with no OneAgent when looking for hosts ([#257](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/257))
 
 ## v0.7
 

--- a/pkg/dtclient/dynatrace_client.go
+++ b/pkg/dtclient/dynatrace_client.go
@@ -145,12 +145,14 @@ func (dc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 	}
 
 	for _, info := range hostInfoResponses {
-
 		hostInfo := hostInfo{entityID: info.EntityID}
 
-		if v := info.AgentVersion; v != nil {
-			hostInfo.version = fmt.Sprintf("%d.%d.%d.%s", v.Major, v.Minor, v.Revision, v.Timestamp)
+		v := info.AgentVersion
+		if v == nil {
+			continue
 		}
+
+		hostInfo.version = fmt.Sprintf("%d.%d.%d.%s", v.Major, v.Minor, v.Revision, v.Timestamp)
 		for _, ip := range info.IPAddresses {
 			dc.hostCache[ip] = hostInfo
 		}

--- a/pkg/dtclient/dynatrace_client_test.go
+++ b/pkg/dtclient/dynatrace_client_test.go
@@ -176,3 +176,43 @@ func writeError(w http.ResponseWriter, status int) {
 	w.WriteHeader(status)
 	_, _ = w.Write(result)
 }
+
+func TestIgnoreHostsWithNoVersions(t *testing.T) {
+	c := dynatraceClient{}
+	require.NoError(t, c.setHostCacheFromResponse([]byte(`[
+	{
+		"entityId": "HOST-42",
+		"displayName": "A",
+		"firstSeenTimestamp": 1589940921731,
+		"lastSeenTimestamp": 1589969061511,
+		"ipAddresses": [
+			"1.1.1.1"
+		],
+		"monitoringMode": "FULL_STACK",
+		"networkZoneId": "default",
+		"agentVersion": {
+			"major": 1,
+			"minor": 195,
+			"revision": 0,
+			"timestamp": "20200515-045253",
+			"sourceRevision": ""
+		}
+	},
+	{
+		"entityId": "HOST-84",
+		"displayName": "B",
+		"firstSeenTimestamp": 1589767448722,
+		"lastSeenTimestamp": 1589852948530,
+		"ipAddresses": [
+			"1.1.1.1"
+		],
+		"monitoringMode": "FULL_STACK",
+		"networkZoneId": "default"
+	}
+]`)))
+
+	info, err := c.getHostInfoForIP("1.1.1.1")
+	require.NoError(t, err)
+	require.Equal(t, "HOST-42", info.entityID)
+	require.Equal(t, "1.195.0.20200515-045253", info.version)
+}


### PR DESCRIPTION
We can ignore hosts that don't include the OneAgent version (i.e., it's a PaaS host, or no OneAgent is currently running.)