### PR TITLE
Allow to configure location for webhook certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * CA and server certificates are generated for the webhook by the Operator, and renewed automatically after 365 and 7 days, respectively ([#244](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/244))
   * OneAgent app-only package and logs will be stored on `/opt/dynatrace/oneagent-paas` inside the containers by default. It can be configured with the `oneagent.dynatrace.com/install-path` annotation on Pods ([#251](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/251))
   * OneAgent app-only package will be downloaded from the provided tenant by default. It can be configured with the `oneagent.dynatrace.com/installer-url` annotation on Pods ([#258](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/258))
+  * Certificates location can be configured on the webhook server with the `--certs-dir`, `--cert`, and `--cert-key` command line arguments ([#261](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/261))
 
 ### Other changes
 * Removed kubernetes.yaml and openshift.yaml from master and generate them with kustomize instead ([#238](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/238), [#254](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/254))

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -47,6 +47,12 @@ var subcmdCallbacks = map[string]func(ns string, cfg *rest.Config) (manager.Mana
 
 var errBadSubcmd = errors.New("subcommand must be operator, webhook-bootstrapper, or webhook-server")
 
+var  (
+	certsDir string
+	certFile string
+	keyFile string
+)
+
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
@@ -55,6 +61,12 @@ func printVersion() {
 }
 
 func main() {
+	webhookServerFlags := pflag.NewFlagSet("webhook-server", pflag.ExitOnError)
+	webhookServerFlags.StringVar(&certsDir, "certs-dir", "/mnt/webhook-certs", "Directory to look certificates for.")
+	webhookServerFlags.StringVar(&certFile, "cert", "tls.crt", "File name for the public certificate.")
+	webhookServerFlags.StringVar(&keyFile, "cert-key", "tls.key", "File name for the private key.")
+
+	pflag.CommandLine.AddFlagSet(webhookServerFlags)
 	pflag.CommandLine.AddFlagSet(zap.FlagSet())
 	pflag.Set("zap-time-encoding", "iso8601")
 	pflag.Parse()


### PR DESCRIPTION
To support scenarios where our own bootstrapper doesn't handle the webhook objects (e.g., leaving it [to OLM](https://olm.operatorframework.io/docs/advanced-tasks/adding-an-admission-webhook/#certificate-authority-constraints)), we should allow the certificate directory and file names to be configurable.

Adding these command line arguments to the Operator binary,

Name | Description | Default
------ | ------------- | ---------
`--certs-dir` | Directory to look certificate files for. | `/mnt/webhook-certs`
`--cert` | File name of the public certificate inside the directory. | `tls.crt`
`--cert-key` | File name of the private key inside the directory. | `tls.key`

The arguments are only recognized by the `webhook-server` subcommand. For the other subcommands, they are ignored.