### PR TITLE
Refactor workflow from OneAgent controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Include Operator version as a custom property for hosts ([#212](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/212))
 * Ignore hosts with no OneAgent when looking for hosts ([#257](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/257))
 * Adjust permissions for the webhook ([#263](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/263))
+* Refactor workflow from OneAgent controller ([#268](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/268))
 
 ## v0.7
 


### PR DESCRIPTION
The idea here is to refactor the top-level logic of the OneAgent Reconciler. Slightly similar error handling is repeated for several operations, but also uneven so errors for some cases are not logged, etc.

For this implementation, I'm using a new abstraction `reconciliation` to keep track of errors, the reconciliation response, and whether we need to update the OneAgent object's status. At the end, the same error logic is done for all cases, which is fine for our purposes.