### PR TITLE
Handle migration for conditions to operator-sdk's implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Ignore hosts with no OneAgent when looking for hosts ([#257](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/257))
 * Adjust permissions for the webhook ([#263](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/263))
 * Refactor workflow from OneAgent controller ([#268](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/268))
+* Automatically update conditions if migrating from earlier Operator versions ([#269](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/269))
 
 ## v0.7
 

--- a/pkg/controller/utils/dynatrace_client_reconciler.go
+++ b/pkg/controller/utils/dynatrace_client_reconciler.go
@@ -67,6 +67,15 @@ func (r *DynatraceClientReconciler) Reconcile(ctx context.Context, instance dyna
 	}
 
 	updateCR := false
+
+	// To migrate from our implementation for conditions on Operator v0.6-0.7 to operator-sdk's implementation.
+	for i := range sts.Conditions {
+		if sts.Conditions[i].LastTransitionTime.IsZero() {
+			sts.Conditions[i].LastTransitionTime = now
+			updateCR = true
+		}
+	}
+
 	secretKey := ns + ":" + secretName
 	secret := &corev1.Secret{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: secretName, Namespace: ns}, secret); k8serrors.IsNotFound(err) {


### PR DESCRIPTION
We moved to use the operator-sdk's implementation for Conditions from the one we had implemented manually previously in previous versions.

The Operator fails to update OneAgent objects on the Kubernetes API, if they were handled by an previous version of the Operator, since the conditions were there but missing LastTransitionTime, a field added by the operator-sdk's library.

This PR updates that field to handle this scenario.