### PR TITLE
Ignore hosts based on when they were last seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * Include Service and MutatingWebhookConfiguration objects in manifests ([#262](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/262), [#266](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/266))
 * Upgrade base image to ubi-minimal:8.2 ([#255](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/255))
 * Include Operator version as a custom property for hosts ([#212](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/212))
-* Ignore hosts with no OneAgent when looking for hosts ([#257](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/257))
+* Ignore hosts that haven't seen in the last 30 minutes when looking for hosts ([#271](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/271), [~~#257~~](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/257))
 * Adjust permissions for the webhook ([#263](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/263))
 * Refactor workflow from OneAgent controller ([#268](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/268))
 * Automatically update conditions if migrating from earlier Operator versions ([#269](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/269))

--- a/pkg/dtclient/agent_version_test.go
+++ b/pkg/dtclient/agent_version_test.go
@@ -19,8 +19,9 @@ const (
 
 const hostsResponse = `[
   {
-	"entityId": "dynatraceSampleEntityId",
+    "entityId": "dynatraceSampleEntityId",
     "displayName": "good",
+    "lastSeenTimestamp": 1521540000000,
     "ipAddresses": [
       "10.11.12.13",
       "192.168.0.1"

--- a/pkg/dtclient/dynatrace_client.go
+++ b/pkg/dtclient/dynatrace_client.go
@@ -152,13 +152,13 @@ func (dc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 		return err
 	}
 
-	// If we haven't seen this host in the last 30 minutes, ignore it.
 	now := dc.now
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
 
 	for _, info := range hostInfoResponses {
+		// If we haven't seen this host in the last 30 minutes, ignore it.
 		if tm := time.Unix(info.LastSeenTimestamp/1000, 0).UTC(); tm.Before(now.Add(-30 * time.Minute)) {
 			continue
 		}

--- a/pkg/dtclient/dynatrace_client.go
+++ b/pkg/dtclient/dynatrace_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -26,6 +27,9 @@ type dynatraceClient struct {
 	httpClient *http.Client
 
 	hostCache map[string]hostInfo
+
+	// Set for testing purposes, leave the default zero value to use the current time.
+	now time.Time
 }
 
 type tokenType int
@@ -134,8 +138,9 @@ func (dc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 			Revision  int
 			Timestamp string
 		}
-		EntityID      string
-		NetworkZoneID string
+		EntityID          string
+		NetworkZoneID     string
+		LastSeenTimestamp int64
 	}
 
 	dc.hostCache = make(map[string]hostInfo)
@@ -147,17 +152,26 @@ func (dc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 		return err
 	}
 
+	// If we haven't seen this host in the last 30 minutes, ignore it.
+	now := dc.now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
 	for _, info := range hostInfoResponses {
-		hostInfo := hostInfo{entityID: info.EntityID}
+		if tm := time.Unix(info.LastSeenTimestamp/1000, 0).UTC(); tm.Before(now.Add(-30 * time.Minute)) {
+			continue
+		}
+
 		nz := info.NetworkZoneID
 
 		if (dc.networkZone != "" && nz == dc.networkZone) || (dc.networkZone == "" && (nz == "default" || nz == "")) {
-			v := info.AgentVersion
-			if v == nil {
-				continue
+			hostInfo := hostInfo{entityID: info.EntityID}
+
+			if v := info.AgentVersion; v != nil {
+				hostInfo.version = fmt.Sprintf("%d.%d.%d.%s", v.Major, v.Minor, v.Revision, v.Timestamp)
 			}
 
-			hostInfo.version = fmt.Sprintf("%d.%d.%d.%s", v.Major, v.Minor, v.Revision, v.Timestamp)
 			for _, ip := range info.IPAddresses {
 				dc.hostCache[ip] = hostInfo
 			}


### PR DESCRIPTION
Looks like my fix on #257 brought some issues. In particular, the OneAgent version is removed from the host entry shortly after the OneAgent stops running, so if the Marked for Termination event is sent afterwards we may end up ignoring the correct host.

This PR changes the logic to ignore hosts that haven't seen on the last 30 minutes on the Dynatrace API which should also solve the original problem.