### PR TITLE
Remove unused metadata from webhook-injected Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Adjust permissions for the webhook ([#263](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/263))
 * Refactor workflow from OneAgent controller ([#268](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/268))
 * Automatically update conditions if migrating from earlier Operator versions ([#269](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/269))
+* Remove unused metadata from webhook-injected Pods ([#272](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/272))
 
 ## v0.7
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -228,12 +228,7 @@ unzip -o -d "${target_dir}" "${archive}"
 rm -f "${archive}"
 
 echo "Configuring OneAgent..."
-mkdir -p "${target_dir}/agent/conf/pod"
-mkdir -p "${target_dir}/agent/conf/node"
-
 echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"
-echo -n "${NODENAME}" > "${target_dir}/agent/conf/node/name"
-echo -n "${NODEIP}" > "${target_dir}/agent/conf/node/ip"
 `))
 
 func (s *script) generate() (map[string][]byte, error) {

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -112,11 +112,6 @@ unzip -o -d "${target_dir}" "${archive}"
 rm -f "${archive}"
 
 echo "Configuring OneAgent..."
-mkdir -p "${target_dir}/agent/conf/pod"
-mkdir -p "${target_dir}/agent/conf/node"
-
 echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"
-echo -n "${NODENAME}" > "${target_dir}/agent/conf/node/name"
-echo -n "${NODEIP}" > "${target_dir}/agent/conf/node/ip"
 `, string(nsSecret.Data["init.sh"]))
 }

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -117,20 +117,6 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 					SecretName: dtwebhook.SecretConfigName,
 				},
 			},
-		},
-		corev1.Volume{
-			Name: "oneagent-podinfo",
-			VolumeSource: corev1.VolumeSource{
-				DownwardAPI: &corev1.DownwardAPIVolumeSource{
-					Items: []corev1.DownwardAPIVolumeFile{
-						{Path: "name", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
-						{Path: "namespace", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
-						{Path: "uid", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"}},
-						{Path: "labels", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels"}},
-						{Path: "annotations", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.annotations"}},
-					},
-				},
-			},
 		})
 
 	var sc *corev1.SecurityContext
@@ -148,18 +134,6 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 			{Name: "TECHNOLOGIES", Value: technologies},
 			{Name: "INSTALLPATH", Value: installPath},
 			{Name: "INSTALLER_URL", Value: installerUrl},
-			{
-				Name: "NODENAME",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-				},
-			},
-			{
-				Name: "NODEIP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
-				},
-			},
 		},
 		SecurityContext: sc,
 		VolumeMounts: []corev1.VolumeMount{
@@ -177,13 +151,10 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 				MountPath: "/etc/ld.so.preload",
 				SubPath:   "ld.so.preload",
 			},
-			corev1.VolumeMount{Name: "oneagent", MountPath: installPath},
-			corev1.VolumeMount{Name: "oneagent-podinfo", MountPath: installPath + "/agent/conf/pod"})
+			corev1.VolumeMount{Name: "oneagent", MountPath: installPath})
 
 		c.Env = append(c.Env,
-			corev1.EnvVar{Name: "LD_PRELOAD", Value: installPath + "/agent/lib64/liboneagentproc.so"},
-			corev1.EnvVar{Name: "DT_CONTAINER_NAME", Value: c.Name},
-			corev1.EnvVar{Name: "DT_CONTAINER_IMAGE", Value: c.Image})
+			corev1.EnvVar{Name: "LD_PRELOAD", Value: installPath + "/agent/lib64/liboneagentproc.so"})
 
 		if oa.Spec.Proxy != nil && (oa.Spec.Proxy.Value != "" || oa.Spec.Proxy.ValueFrom != "") {
 			c.Env = append(c.Env,

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -104,14 +104,6 @@ func TestPodInjection(t *testing.T) {
 					{Name: "TECHNOLOGIES", Value: "all"},
 					{Name: "INSTALLPATH", Value: "/opt/dynatrace/oneagent-paas"},
 					{Name: "INSTALLER_URL", Value: ""},
-					{
-						Name:      "NODENAME",
-						ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}},
-					},
-					{
-						Name:      "NODEIP",
-						ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"}},
-					},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "oneagent", MountPath: "/mnt/oneagent"},
@@ -123,13 +115,10 @@ func TestPodInjection(t *testing.T) {
 				Image: "alpine",
 				Env: []corev1.EnvVar{
 					{Name: "LD_PRELOAD", Value: "/opt/dynatrace/oneagent-paas/agent/lib64/liboneagentproc.so"},
-					{Name: "DT_CONTAINER_NAME", Value: "test-container"},
-					{Name: "DT_CONTAINER_IMAGE", Value: "alpine"},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "oneagent", MountPath: "/etc/ld.so.preload", SubPath: "ld.so.preload"},
 					{Name: "oneagent", MountPath: "/opt/dynatrace/oneagent-paas"},
-					{Name: "oneagent-podinfo", MountPath: "/opt/dynatrace/oneagent-paas/agent/conf/pod"},
 				},
 			}},
 			Volumes: []corev1.Volume{
@@ -144,20 +133,6 @@ func TestPodInjection(t *testing.T) {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: dtwebhook.SecretConfigName,
-						},
-					},
-				},
-				{
-					Name: "oneagent-podinfo",
-					VolumeSource: corev1.VolumeSource{
-						DownwardAPI: &corev1.DownwardAPIVolumeSource{
-							Items: []corev1.DownwardAPIVolumeFile{
-								{Path: "name", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
-								{Path: "namespace", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
-								{Path: "uid", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"}},
-								{Path: "labels", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels"}},
-								{Path: "annotations", FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.annotations"}},
-							},
 						},
 					},
 				},


### PR DESCRIPTION
On the webhook implementation, I was providing some metadata about the pod and the node to be used by the agent. This is still a work in progress so for our next Operator release it's better to not have it since it's not really used.