### PR TITLE
More changes in preparation for v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * Refactor workflow from OneAgent controller ([#268](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/268))
 * Automatically update conditions if migrating from earlier Operator versions ([#269](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/269))
 * Remove unused metadata from webhook-injected Pods ([#272](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/272))
-* Changes in preparation for v0.8.0 release ([#273](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/273))
+* Changes in preparation for v0.8.0 release ([#273](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/273), [#274](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/274))
 
 ## v0.7
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -168,7 +168,7 @@ func newScript(ctx context.Context, c client.Client, oaName, ns string) (*script
 		if err := c.Get(ctx, client.ObjectKey{Name: apm.Spec.TrustedCAs, Namespace: ns}, &cam); err != nil {
 			return nil, fmt.Errorf("failed to query ca: %w", err)
 		}
-		trustedCAs = []byte(cam.Data["proxy"])
+		trustedCAs = []byte(cam.Data["certs"])
 	}
 
 	return &script{

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -97,7 +97,11 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 		pod.Annotations = map[string]string{}
 	}
 
+	if pod.Annotations[dtwebhook.AnnotationInjected] == "true" {
+		return admission.Patched("")
+	}
 	pod.Annotations[dtwebhook.AnnotationInjected] = "true"
+
 	flavor := url.QueryEscape(getField(pod.Annotations, dtwebhook.AnnotationFlavor, "default"))
 	technologies := url.QueryEscape(getField(pod.Annotations, dtwebhook.AnnotationTechnologies, "all"))
 	installPath := getField(pod.Annotations, dtwebhook.AnnotationInstallPath, dtwebhook.DefaultInstallPath)


### PR DESCRIPTION
* Use the correct field when extracting the trusted certificates for app-only.
* Do not make any modifications to Pods if they were already processed by the webhook. It's supposedly possible for Kubernetes to send the same object through a webhook multiple times.