### PR TITLE
Keep downloaded package in shared OneAgent volume

### DIFF
--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -231,7 +231,7 @@ if ! unzip -o -d "${target_dir}" "${archive}"; then
 	echo "Failed to unpack the OneAgent package."
 	exit 0
 fi
-rm -f "${archive}"
+mv "${archive}" "${target_dir}/package.zip"
 
 echo "Configuring OneAgent..."
 echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -115,7 +115,7 @@ if ! unzip -o -d "${target_dir}" "${archive}"; then
 	echo "Failed to unpack the OneAgent package."
 	exit 0
 fi
-rm -f "${archive}"
+mv "${archive}" "${target_dir}/package.zip"
 
 echo "Configuring OneAgent..."
 echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"


### PR DESCRIPTION
Temporary change to help with debugging a problem with broken downloads.