### PR TITLE
Update status of OneAgentAPM if token is missing

### DIFF
--- a/pkg/controller/oneagentapm/oneagentapm_controller.go
+++ b/pkg/controller/oneagentapm/oneagentapm_controller.go
@@ -104,7 +104,12 @@ func (r *ReconcileOneAgentAPM) Reconcile(request reconcile.Request) (reconcile.R
 
 	if upd {
 		instance.Status.UpdatedTimestamp = metav1.Now()
+		reconcileError := err
 		if err := r.client.Status().Update(context.TODO(), instance); err != nil {
+			if reconcileError != nil {
+				// If update fails, but previous reconciliation did so too, make sure both errors are logged
+				logger.Error(reconcileError, reconcileError.Error())
+			}
 			return reconcile.Result{}, fmt.Errorf("failed to update OneAgentAPM: %w", err)
 		}
 	}

--- a/pkg/controller/oneagentapm/oneagentapm_controller.go
+++ b/pkg/controller/oneagentapm/oneagentapm_controller.go
@@ -101,15 +101,16 @@ func (r *ReconcileOneAgentAPM) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	dtc, upd, err := r.dtcReconciler.Reconcile(context.TODO(), instance)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
 
 	if upd {
 		instance.Status.UpdatedTimestamp = metav1.Now()
 		if err := r.client.Status().Update(context.TODO(), instance); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to update OneAgentAPM: %w", err)
 		}
+	}
+
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	if instance.Spec.EnableIstio {

--- a/pkg/controller/oneagentapm/oneagentapm_controller_test.go
+++ b/pkg/controller/oneagentapm/oneagentapm_controller_test.go
@@ -26,21 +26,26 @@ func init() {
 	os.Setenv(k8sutil.WatchNamespaceEnvVar, "dynatrace")
 }
 
-func TestReconcileOneAgentAPM(t *testing.T) {
-	name := "oneagent"
-	ns := "dynatrace"
+const (
+	apiUrl    = "https://ENVIRONMENTID.live.dynatrace.com/api"
+	name      = "oneagent"
+	namespace = "dynatrace"
 
+	noTokenError = "Secret 'dynatrace:oneagent' not found"
+)
+
+func TestReconcileOneAgentAPM(t *testing.T) {
 	fakeClient := fake.NewFakeClient(
 		&dynatracev1alpha1.OneAgentAPM{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 			Spec: dynatracev1alpha1.OneAgentAPMSpec{
 				BaseOneAgentSpec: dynatracev1alpha1.BaseOneAgentSpec{
-					APIURL: "https://ENVIRONMENTID.live.dynatrace.com/api",
+					APIURL: apiUrl,
 				},
 			},
 		},
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 			Data:       map[string][]byte{utils.DynatracePaasToken: []byte("42")},
 		},
 	)
@@ -60,14 +65,53 @@ func TestReconcileOneAgentAPM(t *testing.T) {
 		},
 	}
 
-	_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}})
+	_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}})
 	assert.NoError(t, err)
 
 	var result dynatracev1alpha1.OneAgentAPM
-	assert.NoError(t, fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: ns}, &result))
-	assert.Equal(t, ns, result.GetNamespace())
+	assert.NoError(t, fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, &result))
+	assert.Equal(t, namespace, result.GetNamespace())
 	assert.Equal(t, name, result.GetName())
 	assert.True(t, result.Status.Conditions.IsTrueFor(dynatracev1alpha1.PaaSTokenConditionType))
+	assert.True(t, result.Status.Conditions.IsUnknownFor(dynatracev1alpha1.APITokenConditionType))
+	mock.AssertExpectationsForObjects(t, dtClient)
+}
+
+func TestReconcileOneAgentAPM_MissingToken(t *testing.T) {
+	fakeClient := fake.NewFakeClient(
+		&dynatracev1alpha1.OneAgentAPM{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: dynatracev1alpha1.OneAgentAPMSpec{
+				BaseOneAgentSpec: dynatracev1alpha1.BaseOneAgentSpec{
+					APIURL: apiUrl,
+				},
+			},
+		},
+	)
+
+	dtClient := &dtclient.MockDynatraceClient{}
+
+	reconciler := &ReconcileOneAgentAPM{
+		client:    fakeClient,
+		apiReader: fakeClient,
+		scheme:    scheme.Scheme,
+		logger:    logf.ZapLoggerTo(os.Stdout, true),
+		dtcReconciler: &utils.DynatraceClientReconciler{
+			Client:              fakeClient,
+			DynatraceClientFunc: utils.StaticDynatraceClient(dtClient),
+			UpdatePaaSToken:     true,
+		},
+	}
+
+	_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}})
+	assert.NotNil(t, err)
+	assert.Equal(t, noTokenError, err.Error())
+
+	var result dynatracev1alpha1.OneAgentAPM
+	assert.NoError(t, fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, &result))
+	assert.Equal(t, namespace, result.GetNamespace())
+	assert.Equal(t, name, result.GetName())
+	assert.True(t, result.Status.Conditions.IsFalseFor(dynatracev1alpha1.PaaSTokenConditionType))
 	assert.True(t, result.Status.Conditions.IsUnknownFor(dynatracev1alpha1.APITokenConditionType))
 	mock.AssertExpectationsForObjects(t, dtClient)
 }

--- a/pkg/controller/oneagentapm/oneagentapm_controller_test.go
+++ b/pkg/controller/oneagentapm/oneagentapm_controller_test.go
@@ -27,11 +27,9 @@ func init() {
 }
 
 const (
-	apiUrl    = "https://ENVIRONMENTID.live.dynatrace.com/api"
+	apiURL    = "https://ENVIRONMENTID.live.dynatrace.com/api"
 	name      = "oneagent"
 	namespace = "dynatrace"
-
-	noTokenError = "Secret 'dynatrace:oneagent' not found"
 )
 
 func TestReconcileOneAgentAPM(t *testing.T) {
@@ -40,7 +38,7 @@ func TestReconcileOneAgentAPM(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 			Spec: dynatracev1alpha1.OneAgentAPMSpec{
 				BaseOneAgentSpec: dynatracev1alpha1.BaseOneAgentSpec{
-					APIURL: apiUrl,
+					APIURL: apiURL,
 				},
 			},
 		},
@@ -83,7 +81,7 @@ func TestReconcileOneAgentAPM_MissingToken(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 			Spec: dynatracev1alpha1.OneAgentAPMSpec{
 				BaseOneAgentSpec: dynatracev1alpha1.BaseOneAgentSpec{
-					APIURL: apiUrl,
+					APIURL: apiURL,
 				},
 			},
 		},
@@ -105,7 +103,7 @@ func TestReconcileOneAgentAPM_MissingToken(t *testing.T) {
 
 	_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}})
 	assert.NotNil(t, err)
-	assert.Equal(t, noTokenError, err.Error())
+	assert.Equal(t, "Secret 'dynatrace:oneagent' not found", err.Error())
 
 	var result dynatracev1alpha1.OneAgentAPM
 	assert.NoError(t, fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, &result))


### PR DESCRIPTION
Before returning the error, updates status of an OneAgentAPM instance if the token secret is missing.