### PR TITLE
Use hash to recognize DaemonSet changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ### Future
 
 #### Features
-
 * Control whether the init container crashes in case of download failures through the `oneagent.dynatrace.com/failure-policy: fail` annotation, off by default ([#288](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/234))
+
+#### Bug fixes
+* Update status of OneAgentAPM if token is missing ([#285](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/285), [#287](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/287))
+* Marked for termination events are now sent when a node is deleted, or when it's cordoned, and then periodically after each hour while in that state ([#279](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/279))
 
 ## v0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Bug fixes
 * Update status of OneAgentAPM if token is missing ([#285](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/285), [#287](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/287))
 * Marked for termination events are now sent when a node is deleted, or when it's cordoned, and then periodically after each hour while in that state ([#279](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/279))
+* Operator was updating the DaemonSet even if there were no changes ([#289](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/289))
 
 ## v0.8
 

--- a/pkg/dtclient/dynatrace_client.go
+++ b/pkg/dtclient/dynatrace_client.go
@@ -155,10 +155,12 @@ func (dc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 		now = time.Now().UTC()
 	}
 
+	var inactive []string
+
 	for _, info := range hostInfoResponses {
 		// If we haven't seen this host in the last 30 minutes, ignore it.
 		if tm := time.Unix(info.LastSeenTimestamp/1000, 0).UTC(); tm.Before(now.Add(-30 * time.Minute)) {
-			dc.logger.Info("Hosts cache: ignoring inactive host", "id", info.EntityID)
+			inactive = append(inactive, info.EntityID)
 			continue
 		}
 
@@ -179,6 +181,10 @@ func (dc *dynatraceClient) setHostCacheFromResponse(response []byte) error {
 				dc.hostCache[ip] = hostInfo
 			}
 		}
+	}
+
+	if len(inactive) > 0 {
+		dc.logger.Info("Hosts cache: ignoring inactive hosts", "ids", inactive)
 	}
 
 	return nil


### PR DESCRIPTION
The Operator was comparing the expected DaemonSet with what was really on the Kubernetes cluster.

For some fields (e.g. DNS Policy), Kubernetes sets a default if we didn't set it, which was causing the comparison to be true each time, making the Operator update the DaemonSet.

There are multiple ways to solve this problem, but here I implemented it by keeping track of the DaemonSet state with a hash on an annotation on the object. The Operator will generate a DaemonSet template, calculate the hash, and compare.

This means that we won't recognize changes to the DaemonSet done outside of the Operator, but I think it's fine for our use case. We're also under the risk of changes on how the hash is calculated, but it's also fine, since it won't happen often (e.g., adding a new field to the DS after a new Operator release) and when it does it's benign if there were no actual changes to the PodSpec template.