### PR TITLE
Fixes for app-only Docker image configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Features
 * Control whether the init container crashes in case of download failures through the `oneagent.dynatrace.com/failure-policy: fail` annotation, off by default ([#288](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/234))
-* Adaptions to the OneAgent webhook injection ([#286](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/286))
+* Adaptions to the OneAgent webhook injection ([#286](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/286), [#290](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/290))
     * Use image from Dynatrace environment's Docker registry to fetch OneAgent binaries, unless a custom installer URL annotation is set
     * A dedicated OneAgent version can be set as a property now (e.g. 1.185.1). If not set it defaults to the latest version
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -220,9 +220,9 @@ if [[ "${INSTALLER_URL}" != "" ]]; then
     fi
 else
     echo "Copy OneAgent package..."
-    if ! cp -a "/opt/dynatrace/oneagent/." "${target_dir}"; then
+    if ! cp -r "/opt/dynatrace/oneagent/." "${target_dir}"; then
         echo "Failed to copy the OneAgent package."
-		exit 0
+		exit "${fail_code}"
 	fi
 fi
 

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -122,9 +122,9 @@ if [[ "${INSTALLER_URL}" != "" ]]; then
     fi
 else
     echo "Copy OneAgent package..."
-    if ! cp -a "/opt/dynatrace/oneagent/." "${target_dir}"; then
+    if ! cp -r "/opt/dynatrace/oneagent/." "${target_dir}"; then
         echo "Failed to copy the OneAgent package."
-		exit 0
+		exit "${fail_code}"
 	fi
 fi
 

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -264,7 +264,7 @@ func BuildOneAgentAPMImage(apiURL string, flavor string, technologies string, ag
 	image := registry + "/linux/codemodule"
 
 	if flavor != "default" {
-		registry = image + "-musl"
+		image += "-musl"
 	}
 
 	if technologies != "all" {

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -160,3 +160,28 @@ func TestGetDeployment(t *testing.T) {
 	assert.Equal(t, "mydeployment", deploy.Name)
 	assert.Equal(t, "dynatrace", deploy.Namespace)
 }
+
+func TestBuildOneAgentAPMImage(t *testing.T) {
+	var tag string
+	var err error
+
+	tag, err = BuildOneAgentAPMImage("https://test-url.com/api", "default", "all", "")
+	assert.NoError(t, err)
+	assert.Equal(t, tag, "test-url.com/linux/codemodule")
+
+	tag, err = BuildOneAgentAPMImage("https://test-url.com/api", "default", "dotnet", "")
+	assert.NoError(t, err)
+	assert.Equal(t, tag, "test-url.com/linux/codemodule:dotnet")
+
+	tag, err = BuildOneAgentAPMImage("https://test-url.com/api", "musl", "java", "")
+	assert.NoError(t, err)
+	assert.Equal(t, tag, "test-url.com/linux/codemodule-musl:java")
+
+	tag, err = BuildOneAgentAPMImage("https://test-url.com/api", "musl", "php,nginx", "1.123")
+	assert.NoError(t, err)
+	assert.Equal(t, tag, "test-url.com/linux/codemodule-musl:php-nginx-1.123")
+
+	tag, err = BuildOneAgentAPMImage("https://10.0.0.1/e/abc123456/api", "musl", "all", "1.123")
+	assert.NoError(t, err)
+	assert.Equal(t, tag, "10.0.0.1/e/abc123456/linux/codemodule-musl:1.123")
+}


### PR DESCRIPTION
* Use `-r` for copying files, since `-a` fails if not running as root.
* Return `${fail_code}` on cp failures.
* Use correct tag for musl images.