### PR TITLE
Generate container.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Marked for termination events are now sent when a node is deleted, or when it's cordoned, and then periodically after each hour while in that state ([#279](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/279))
 * Operator was updating the DaemonSet even if there were no changes ([#289](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/289))
 
+#### Other changes
+* Pod and node metadata added for the OneAgent ([#294](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/294))
+
 ## v0.8
 
 ### [v0.8.0](https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/tag/v0.8.0)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.6.1
 	istio.io/api v0.0.0-20191109011911-e51134872853
 	istio.io/client-go v0.0.0-20191119175647-1aefa51f7583
 	k8s.io/api v0.17.4

--- a/go.sum
+++ b/go.sum
@@ -769,6 +769,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -1133,6 +1135,8 @@ gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 helm.sh/helm/v3 v3.1.0/go.mod h1:WYsFJuMASa/4XUqLyv54s0U/f3mlAaRErGmyy4z921g=
 helm.sh/helm/v3 v3.1.2/go.mod h1:WYsFJuMASa/4XUqLyv54s0U/f3mlAaRErGmyy4z921g=

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"text/template"
 	"time"
 
@@ -35,6 +36,7 @@ func Add(mgr manager.Manager) error {
 		namespace:               ns,
 		logger:                  log.Log.WithName("namespaces.controller"),
 		pullSecretGeneratorFunc: utils.GeneratePullSecretData,
+		addNodeProps:            os.Getenv("ONEAGENT_OPERATOR_DEBUG_NODE_PROPERTIES") == "true",
 	})
 }
 
@@ -60,6 +62,7 @@ type ReconcileNamespaces struct {
 	logger                  logr.Logger
 	namespace               string
 	pullSecretGeneratorFunc func(c client.Client, apm *dynatracev1alpha1.OneAgentAPM, tkns *corev1.Secret) (map[string][]byte, error)
+	addNodeProps            bool
 }
 
 func (r *ReconcileNamespaces) Reconcile(request reconcile.Request) (reconcile.Result, error) {
@@ -100,6 +103,7 @@ func (r *ReconcileNamespaces) Reconcile(request reconcile.Request) (reconcile.Re
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to generate init script: %w", err)
 	}
+	script.AddNodeProps = r.addNodeProps
 
 	data, err := script.generate()
 	if err != nil {
@@ -128,13 +132,20 @@ func (r *ReconcileNamespaces) Reconcile(request reconcile.Request) (reconcile.Re
 }
 
 type script struct {
-	OneAgent   *dynatracev1alpha1.OneAgentAPM
-	PaaSToken  string
-	Proxy      string
-	TrustedCAs []byte
+	OneAgent     *dynatracev1alpha1.OneAgentAPM
+	PaaSToken    string
+	Proxy        string
+	TrustedCAs   []byte
+	ClusterID    string
+	AddNodeProps bool
 }
 
 func newScript(ctx context.Context, c client.Client, apm dynatracev1alpha1.OneAgentAPM, tkns corev1.Secret, ns string) (*script, error) {
+	var kubeSystemNS corev1.Namespace
+	if err := c.Get(ctx, client.ObjectKey{Name: "kube-system"}, &kubeSystemNS); err != nil {
+		return nil, fmt.Errorf("failed to query for cluster ID: %w", err)
+	}
+
 	var proxy string
 	if apm.Spec.Proxy != nil {
 		if apm.Spec.Proxy.ValueFrom != "" {
@@ -162,6 +173,7 @@ func newScript(ctx context.Context, c client.Client, apm dynatracev1alpha1.OneAg
 		PaaSToken:  string(tkns.Data[utils.DynatracePaasToken]),
 		Proxy:      proxy,
 		TrustedCAs: trustedCAs,
+		ClusterID:  string(kubeSystemNS.UID),
 	}, nil
 }
 
@@ -178,18 +190,19 @@ skip_cert_checks="{{if .OneAgent.Spec.SkipCertCheck}}true{{else}}false{{end}}"
 custom_ca="{{if .TrustedCAs}}true{{else}}false{{end}}"
 installer_url="${api_url}/v1/deployment/installer/agent/unix/paas/latest?flavor=${FLAVOR}&include=${TECHNOLOGIES}&bitness=64"
 fail_code=0
+cluster_id="{{.ClusterID}}"
 
 archive=$(mktemp)
+
+if [[ "${FAILURE_POLICY}" == "fail" ]]; then
+	fail_code=1
+fi
 
 # Work around to use installer URL until we have the image.
 #if [[ "${INSTALLER_URL}" != "" ]]; then
 
 if [[ "${INSTALLER_URL}" != "" ]]; then
 	installer_url="${INSTALLER_URL}"
-fi
-
-if [[ "${FAILURE_POLICY}" == "fail" ]]; then
-	fail_code=1
 fi
 
 curl_params=(
@@ -237,6 +250,33 @@ rm -f "${archive}"
 
 echo "Configuring OneAgent..."
 echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"
+
+for i in $(seq 1 $CONTAINERS_COUNT)
+do
+	container_name_var="CONTAINER_${i}_NAME"
+	container_image_var="CONTAINER_${i}_IMAGE"
+
+	container_name="${!container_name_var}"
+	container_image="${!container_image_var}"
+
+	container_conf_file="${target_dir}/container_${container_name}.conf"
+
+	echo "Writing ${container_conf_file} file..."
+	cat <<EOF >${container_conf_file}
+[container]
+containerName ${container_name}
+imageName ${container_image}
+k8s_fullpodname ${K8S_PODNAME}
+k8s_poduid ${K8S_PODUID}
+k8s_containername ${container_name}
+k8s_basepodname ${K8S_BASEPODNAME}
+k8s_namespace ${K8S_NAMESPACE}
+{{- if .AddNodeProps}}
+k8s_node_name ${K8S_NODE_NAME}
+k8s_cluster_id ${cluster_id}
+{{- end}}
+EOF
+done
 `))
 
 func (s *script) generate() (map[string][]byte, error) {

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -40,6 +40,12 @@ func TestReconcileNamespace(t *testing.T) {
 				Labels: map[string]string{"oneagent.dynatrace.com/instance": "oneagent"},
 			},
 		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-system",
+				UID:  types.UID("42"),
+			},
+		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "oneagent", Namespace: "dynatrace"},
 			Data:       map[string][]byte{"paasToken": []byte("42"), "apiToken": []byte("84")},
@@ -54,6 +60,7 @@ func TestReconcileNamespace(t *testing.T) {
 		pullSecretGeneratorFunc: func(c client.Client, apm *dynatracev1alpha1.OneAgentAPM, tkns *corev1.Secret) (map[string][]byte, error) {
 			return map[string][]byte{".dockerconfigjson": []byte("{}")}, nil
 		},
+		addNodeProps: false,
 	}
 
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-namespace"}})
@@ -80,18 +87,19 @@ skip_cert_checks="false"
 custom_ca="false"
 installer_url="${api_url}/v1/deployment/installer/agent/unix/paas/latest?flavor=${FLAVOR}&include=${TECHNOLOGIES}&bitness=64"
 fail_code=0
+cluster_id="42"
 
 archive=$(mktemp)
+
+if [[ "${FAILURE_POLICY}" == "fail" ]]; then
+	fail_code=1
+fi
 
 # Work around to use installer URL until we have the image.
 #if [[ "${INSTALLER_URL}" != "" ]]; then
 
 if [[ "${INSTALLER_URL}" != "" ]]; then
 	installer_url="${INSTALLER_URL}"
-fi
-
-if [[ "${FAILURE_POLICY}" == "fail" ]]; then
-	fail_code=1
 fi
 
 curl_params=(
@@ -139,5 +147,28 @@ rm -f "${archive}"
 
 echo "Configuring OneAgent..."
 echo -n "${INSTALLPATH}/agent/lib64/liboneagentproc.so" >> "${target_dir}/ld.so.preload"
+
+for i in $(seq 1 $CONTAINERS_COUNT)
+do
+	container_name_var="CONTAINER_${i}_NAME"
+	container_image_var="CONTAINER_${i}_IMAGE"
+
+	container_name="${!container_name_var}"
+	container_image="${!container_image_var}"
+
+	container_conf_file="${target_dir}/container_${container_name}.conf"
+
+	echo "Writing ${container_conf_file} file..."
+	cat <<EOF >${container_conf_file}
+[container]
+containerName ${container_name}
+imageName ${container_image}
+k8s_fullpodname ${K8S_PODNAME}
+k8s_poduid ${K8S_PODUID}
+k8s_containername ${container_name}
+k8s_basepodname ${K8S_BASEPODNAME}
+k8s_namespace ${K8S_NAMESPACE}
+EOF
+done
 `, string(nsSecret.Data["init.sh"]))
 }

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
+	"strings"
 
 	dynatracev1alpha1 "github.com/Dynatrace/dynatrace-oneagent-operator/pkg/apis/dynatrace/v1alpha1"
 	"github.com/Dynatrace/dynatrace-oneagent-operator/pkg/controller/utils"
@@ -153,7 +155,21 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 		pod.Spec.ImagePullSecrets = append(pod.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: dtwebhook.PullSecretName})
 	}
 
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+	fieldEnvVar := func(key string) *corev1.EnvVarSource {
+		return &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: key}}
+	}
+
+	basePodName := pod.GenerateName
+	if basePodName == "" {
+		basePodName = pod.Name
+	}
+
+	// Only include up to the last dash character, exclusive.
+	if p := strings.LastIndex(basePodName, "-"); p != -1 {
+		basePodName = basePodName[:p]
+	}
+
+	ic := corev1.Container{
 		Name:    "install-oneagent",
 		Image:   image,
 		Command: []string{"/usr/bin/env"},
@@ -164,16 +180,26 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 			{Name: "INSTALLPATH", Value: installPath},
 			{Name: "INSTALLER_URL", Value: installerUrl},
 			{Name: "FAILURE_POLICY", Value: failurePolicy},
+			{Name: "CONTAINERS_COUNT", Value: strconv.Itoa(len(pod.Spec.Containers))},
+			{Name: "K8S_PODNAME", ValueFrom: fieldEnvVar("metadata.name")},
+			{Name: "K8S_PODUID", ValueFrom: fieldEnvVar("metadata.uid")},
+			{Name: "K8S_BASEPODNAME", Value: basePodName},
+			{Name: "K8S_NAMESPACE", ValueFrom: fieldEnvVar("metadata.namespace")},
+			{Name: "K8S_NODE_NAME", ValueFrom: fieldEnvVar("spec.nodeName")},
 		},
 		SecurityContext: sc,
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "oneagent", MountPath: "/mnt/oneagent"},
 			{Name: "oneagent-config", MountPath: "/mnt/config"},
 		},
-	})
+	}
 
 	for i := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[i]
+
+		ic.Env = append(ic.Env,
+			corev1.EnvVar{Name: fmt.Sprintf("CONTAINER_%d_NAME", i+1), Value: c.Name},
+			corev1.EnvVar{Name: fmt.Sprintf("CONTAINER_%d_IMAGE", i+1), Value: c.Image})
 
 		c.VolumeMounts = append(c.VolumeMounts,
 			corev1.VolumeMount{
@@ -181,7 +207,12 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 				MountPath: "/etc/ld.so.preload",
 				SubPath:   "ld.so.preload",
 			},
-			corev1.VolumeMount{Name: "oneagent", MountPath: installPath})
+			corev1.VolumeMount{Name: "oneagent", MountPath: installPath},
+			corev1.VolumeMount{
+				Name:      "oneagent",
+				MountPath: installPath + "/agent/conf/container.conf",
+				SubPath:   fmt.Sprintf("container_%s.conf", c.Name),
+			})
 
 		c.Env = append(c.Env,
 			corev1.EnvVar{Name: "LD_PRELOAD", Value: installPath + "/agent/lib64/liboneagentproc.so"})
@@ -205,6 +236,8 @@ func (m *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 			c.Env = append(c.Env, corev1.EnvVar{Name: "DT_NETWORK_ZONE", Value: oa.Spec.NetworkZone})
 		}
 	}
+
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, ic)
 
 	marshaledPod, err := json.MarshalIndent(pod, "", "  ")
 	if err != nil {

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -49,7 +49,7 @@ func TestPodInjection(t *testing.T) {
 	}
 
 	basePod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "test-namespace"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod-123456", Namespace: "test-namespace"},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
 				Name:  "test-container",
@@ -89,7 +89,7 @@ func TestPodInjection(t *testing.T) {
 
 	assert.Equal(t, corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
+			Name:      "test-pod-123456",
 			Namespace: "test-namespace",
 			Annotations: map[string]string{
 				"oneagent.dynatrace.com/injected": "true",
@@ -108,6 +108,14 @@ func TestPodInjection(t *testing.T) {
 					{Name: "INSTALLPATH", Value: "/opt/dynatrace/oneagent-paas"},
 					{Name: "INSTALLER_URL", Value: ""},
 					{Name: "FAILURE_POLICY", Value: "silent"},
+					{Name: "CONTAINERS_COUNT", Value: "1"},
+					{Name: "K8S_PODNAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
+					{Name: "K8S_PODUID", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"}}},
+					{Name: "K8S_BASEPODNAME", Value: "test-pod"},
+					{Name: "K8S_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+					{Name: "K8S_NODE_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+					{Name: "CONTAINER_1_NAME", Value: "test-container"},
+					{Name: "CONTAINER_1_IMAGE", Value: "alpine"},
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "oneagent", MountPath: "/mnt/oneagent"},
@@ -123,6 +131,11 @@ func TestPodInjection(t *testing.T) {
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "oneagent", MountPath: "/etc/ld.so.preload", SubPath: "ld.so.preload"},
 					{Name: "oneagent", MountPath: "/opt/dynatrace/oneagent-paas"},
+					{
+						Name:      "oneagent",
+						MountPath: "/opt/dynatrace/oneagent-paas/agent/conf/container.conf",
+						SubPath:   "container_test-container.conf",
+					},
 				},
 			}},
 			Volumes: []corev1.Volume{


### PR DESCRIPTION
* A `container.conf` file will be added at `/opt/dynatrace/oneagent-paas/agent/conf/container.conf` with Pod metadata.
  * The file is generated by the init container for every container running on the Pod. The Operator mounts the corresponding one for each container.
* Some cluster/node metadata can be added as well when setting the `ONEAGENT_OPERATOR_DEBUG_NODE_PROPERTIES=true` environment variable on the Operator Pod (not the Webhook Pod.)
* Upgraded testify, it gives better diffs for objects now.