### PR TITLE
Add release tasks for Quay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,11 @@ jobs:
       env: IMAGE=$OAO_IMAGE_DOCKER_HUB
 
     - <<: *deploy_amd
+      name: Deploy release AMD to Quay
+      if: tag =~ /^v.*/
+      env: IMAGE=$OAO_IMAGE_QUAY
+
+    - <<: *deploy_amd
       name: Deploy release AMD to RHCC
       if: tag =~ /^v.*/
       env: IMAGE=$OAO_IMAGE_RHCC_SCAN
@@ -156,6 +161,11 @@ jobs:
       if: tag =~ /^v.*/
       env: IMAGE=$OAO_IMAGE_DOCKER_HUB
 
+    - <<: *deploy_arm
+      name: Deploy release ARM to Quay
+      if: tag =~ /^v.*/
+      env: IMAGE=$OAO_IMAGE_QUAY
+
       ######################### Create Docker manifest #########################
 
     - &create_manifest
@@ -168,16 +178,28 @@ jobs:
       git:
         clone: false
       script:
+        - sudo chmod o+x /etc/docker
         - docker manifest create $IMAGE:$TAG $IMAGE:$TAG-arm64 $IMAGE:$TAG-amd64
         - docker manifest push $IMAGE:$TAG
       workspaces:
         use: dockerconfig
 
     - <<: *create_manifest
+      name: Create manifest for non-master snapshot for Quay
+      if: (branch != master) AND (tag IS blank)
+      env: IMAGE=$OAO_IMAGE_QUAY TAG="snapshot-$(echo $TRAVIS_BRANCH | sed 's#[^a-zA-Z0-9_-]#-#g')"
+
+    - <<: *create_manifest
       stage: manifest
       name: Create manifest for release for DockerHub
       if: tag =~ /^v.*/
       env: IMAGE=$OAO_IMAGE_DOCKER_HUB
+
+    - <<: *create_manifest
+      stage: manifest
+      name: Create manifest for release for Quay
+      if: tag =~ /^v.*/
+      env: IMAGE=$OAO_IMAGE_QUAY
 
       ######################### Prepare CSV #########################
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Adaptions to the OneAgent webhook injection ([#286](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/286), [#290](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/290), [#301](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/301))
     * Use image from Dynatrace environment's Docker registry to fetch OneAgent binaries, unless a custom installer URL annotation is set
     * A dedicated OneAgent version can be set as a property now (e.g. 1.185.1). If not set it defaults to the latest version
+* Publish Operator stable images also to Quay ([#304](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/304))
 
 #### Bug fixes
 * Update status of OneAgentAPM if token is missing ([#285](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/285), [#287](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/287))
@@ -14,7 +15,6 @@
 * Operator was updating the DaemonSet even if there were no changes ([#289](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/289))
 * Certificates secret not updated on renewal, causing renewals every 5 minutes ([#297](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/297))
 * Logged errors when API token is missing on OneAgentAPM's secret ([#298](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/298))
-
 
 #### Other changes
 * Pod and node metadata added for the OneAgent ([#294](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/294), [#295](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/295))


### PR DESCRIPTION
This PR,
* Publish multi-arch images for stable versions to Quay.
* Pushes multi-arch manifests to Quay for non-master branches.

The `chmod o+x /etc/docker` command is a workaround for https://github.com/docker/for-linux/issues/396 that Travis CI seems to exhibit.