### PR TITLE
Add unprivileged mode for OneAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Added a resource limit and resource request for the OneAgentAPM initContainer ([#315](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/315), [#317](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/317))
 * Add linter to TravisCI pipeline ([#316](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/316))
 * App-only init container will log an warning when the full-stack OneAgent has been injected on it ([#323](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/323))
+* Experimental: support full-stack OneAgent running on non-privileged mode ([#324](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/324))
 
 ## v0.8
 

--- a/deploy/common/deployment-operator.yaml
+++ b/deploy/common/deployment-operator.yaml
@@ -36,6 +36,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ONEAGENT_OPERATOR_DEBUG_UNPRIVILEGED
+              value: "true"
           ports:
             - containerPort: 8080
               name: metrics

--- a/deploy/common/kustomization.yaml
+++ b/deploy/common/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - rolebinding-webhook.yaml
 - service.yaml
 - serviceaccount-oneagent.yaml
+- serviceaccount-oneagent-unprivileged.yaml
 - serviceaccount-operator.yaml
 - serviceaccount-webhook.yaml
 bases:

--- a/deploy/common/serviceaccount-oneagent-unprivileged.yaml
+++ b/deploy/common/serviceaccount-oneagent-unprivileged.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-oneagent-unprivileged
+  namespace: dynatrace

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -2,10 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - podsecuritypolicy-oneagent.yaml
+- podsecuritypolicy-oneagent-unprivileged.yaml
 - podsecuritypolicy-operator.yaml
 - podsecuritypolicy-webhook.yaml
 - role-oneagent.yaml
+- role-oneagent-unprivileged.yaml
 - rolebinding-oneagent.yaml
+- rolebinding-oneagent-unprivileged.yaml
 bases:
   - ../common
 patchesJson6902:

--- a/deploy/kubernetes/podsecuritypolicy-oneagent-unprivileged.yaml
+++ b/deploy/kubernetes/podsecuritypolicy-oneagent-unprivileged.yaml
@@ -1,0 +1,44 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: dynatrace-oneagent-unprivileged
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: "unconfined"
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+spec:
+  privileged: false
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - CHOWN
+    - DAC_OVERRIDE
+    - DAC_READ_SEARCH
+    - FOWNER
+    - FSETID
+    - KILL
+    - NET_ADMIN
+    - NET_RAW
+    - SETFCAP
+    - SETGID
+    - SETUID
+    - SYS_ADMIN
+    - SYS_CHROOT
+    - SYS_PTRACE
+    - SYS_RESOURCE
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - "*"
+  hostNetwork: true
+  hostIPC: true
+  hostPID: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  runAsUser:
+    rule: "RunAsAny"
+  seLinux:
+    rule: "RunAsAny"
+  supplementalGroups:
+    rule: "RunAsAny"
+  fsGroup:
+    rule: "RunAsAny"

--- a/deploy/kubernetes/role-oneagent-unprivileged.yaml
+++ b/deploy/kubernetes/role-oneagent-unprivileged.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dynatrace-oneagent-unprivileged
+  namespace: dynatrace
+rules:
+  - apiGroups:
+      - policy
+    resources:
+      - podsecuritypolicies
+    resourceNames:
+      - dynatrace-oneagent-unprivileged
+    verbs:
+      - use

--- a/deploy/kubernetes/rolebinding-oneagent-unprivileged.yaml
+++ b/deploy/kubernetes/rolebinding-oneagent-unprivileged.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dynatrace-oneagent-unprivileged
+  namespace: dynatrace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dynatrace-oneagent-unprivileged
+subjects:
+  - kind: ServiceAccount
+    name: dynatrace-oneagent-unprivileged
+    namespace: dynatrace

--- a/deploy/openshift/kustomization.yaml
+++ b/deploy/openshift/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - securitycontextconstraints.yaml
+- securitycontextconstraints-unprivileged.yaml
 bases:
   - ../common
 patchesJson6902:

--- a/deploy/openshift/securitycontextconstraints-unprivileged.yaml
+++ b/deploy/openshift/securitycontextconstraints-unprivileged.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: "dynatrace-oneagent-privileged allows access to all privileged and host features and the ability to run as any user, any group, any fsGroup, and with any SELinux context. This is a copy of privileged scc."
+  name: dynatrace-oneagent-unprivileged
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - CHOWN
+  - DAC_OVERRIDE
+  - DAC_READ_SEARCH
+  - FOWNER
+  - FSETID
+  - KILL
+  - NET_ADMIN
+  - NET_RAW
+  - SETFCAP
+  - SETGID
+  - SETUID
+  - SYS_ADMIN
+  - SYS_CHROOT
+  - SYS_PTRACE
+  - SYS_RESOURCE
+allowedFlexVolumes: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - "*"
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:dynatrace:dynatrace-oneagent-unprivileged
+volumes:
+  - "*"

--- a/pkg/controller/oneagent/oneagent_controller_test.go
+++ b/pkg/controller/oneagent/oneagent_controller_test.go
@@ -316,7 +316,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		pod.Name = "oneagent-update-enabled"
 		pod.Namespace = namespace
 		pod.Labels = buildLabels(oaName)
-		pod.Spec = newPodSpecForCR(oa, consoleLogger)
+		pod.Spec = newPodSpecForCR(oa, false, consoleLogger)
 		pod.Status.HostIP = hostIP
 		oa.Status.Tokens = utils.GetTokensName(oa)
 
@@ -343,7 +343,7 @@ func TestReconcile_InstancesSet(t *testing.T) {
 		pod.Name = "oneagent-update-disabled"
 		pod.Namespace = namespace
 		pod.Labels = buildLabels(oaName)
-		pod.Spec = newPodSpecForCR(oa, consoleLogger)
+		pod.Spec = newPodSpecForCR(oa, false, consoleLogger)
 		pod.Status.HostIP = hostIP
 		oa.Status.Tokens = utils.GetTokensName(oa)
 


### PR DESCRIPTION
On this PR we're trying to add experimental support for the OneAgent to run in non-privileged mode by setting the required capabilities explicitly.

Since it's an experiment, this is currently controlled by the environment variable `ONEAGENT_OPERATOR_DEBUG_UNPRIVILEGED`, which if `"true"`, then this mode will be used for the full-stack OneAgent Pods.

Now, the feature is optional, and since the PodSecurityPolicy and SecurityContextConstraints are quite different between each mode, I'm adding new instances for these types when running on unprivileged, as well as the ServiceAccount assigned to them.

The default ServiceAccount for the OneAgent Pods will be chosen depending on the mode.