### PR TITLE
Include node metadata on OneAgent Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * Fixed logging problem - [incorrect stackdriver severity on GCP](https://github.com/Dynatrace/dynatrace-oneagent-operator/issues/277) ([#318](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/318))
 
 #### Other changes
-* Pod and node metadata added for the OneAgent ([#294](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/294), [#295](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/295), [#308](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/308), [#325](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/325))
+* Pod and node metadata added for the OneAgent ([#294](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/294), [#295](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/295), [#308](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/308), [#325](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/325), [#326](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/326))
 * Code cleanup to remove unused functions, variables and beautify the code ([#302](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/302))
 * Sped up TravisCI duration ([#310](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/310), [#312](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/312))
 * Upgrade to Go 1.15 ([#310](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/310))

--- a/pkg/controller/oneagent/oneagent_utils_test.go
+++ b/pkg/controller/oneagent/oneagent_utils_test.go
@@ -51,7 +51,7 @@ func TestMigrationForDaemonSetWithoutAnnotation(t *testing.T) {
 
 	ds1 := &appsv1.DaemonSet{ObjectMeta: oaKey}
 
-	ds2, err := newDaemonSetForCR(consoleLogger, &dynatracev1alpha1.OneAgent{ObjectMeta: oaKey})
+	ds2, err := newDaemonSetForCR(consoleLogger, &dynatracev1alpha1.OneAgent{ObjectMeta: oaKey}, "cluster1")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, ds2.Annotations[annotationTemplateHash])
 
@@ -67,10 +67,10 @@ func TestHasSpecChanged(t *testing.T) {
 
 			mod(&old, &new)
 
-			ds1, err := newDaemonSetForCR(consoleLogger, &old)
+			ds1, err := newDaemonSetForCR(consoleLogger, &old, "cluster1")
 			assert.NoError(t, err)
 
-			ds2, err := newDaemonSetForCR(consoleLogger, &new)
+			ds2, err := newDaemonSetForCR(consoleLogger, &new, "cluster1")
 			assert.NoError(t, err)
 
 			assert.NotEmpty(t, ds1.Annotations[annotationTemplateHash])


### PR DESCRIPTION
This PR adds the `DT_K8S_NODE_NAME` and `DT_K8S_CLUSTER_ID` environment variables to OneAgent Pods.

Given that `prepareEnvVars()` was being skipped for immutable images (and the new environment variables are needed here), I've updated the function to handle both cases.