### PR TITLE
Improve error message when OneAgentAPM instance doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add linter to TravisCI pipeline ([#316](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/316))
 * App-only init container will log an warning when the full-stack OneAgent has been injected on it ([#323](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/323))
 * Experimental: support full-stack OneAgent running on non-privileged mode ([#324](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/324))
+* Improve error message when OneAgentAPM is missing ([#327](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/327))
 
 ## v0.8
 


### PR DESCRIPTION
This PR changes the error message when you run `kubectl describe rs <your-replica-set>` when a namespace is supposed to be monitored by an OneAgentAPM instance, but this doesn't exist, e.g.,

```
namespace 'my-namespace' is assigned to OneAgentAPM instance 'missing-oneagent' but doesn't exist
```