### PR TITLE
Configure unprivileged mode on OneAgent CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Added a resource limit and resource request for the OneAgentAPM initContainer ([#315](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/315), [#317](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/317))
 * Add linter to TravisCI pipeline ([#316](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/316))
 * App-only init container will log an warning when the full-stack OneAgent has been injected on it ([#323](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/323))
-* Experimental: support full-stack OneAgent running on non-privileged mode ([#324](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/324))
+* Early Preview: support full-stack OneAgent running on unprivileged mode ([#324](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/324), [#332](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/332))
 * Improve error message when OneAgentAPM is missing ([#327](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/327))
 * Improve descriptions on cr.yaml example ([#328](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/328))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Added a resource limit and resource request for the OneAgentAPM initContainer ([#315](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/315), [#317](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/317))
 * Add linter to TravisCI pipeline ([#316](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/316))
 * App-only init container will log an warning when the full-stack OneAgent has been injected on it ([#323](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/323))
-* Early Preview: support full-stack OneAgent running on unprivileged mode ([#324](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/324), [#332](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/332))
+* Early Adopter: support full-stack OneAgent running on unprivileged mode ([#324](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/324), [#332](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/332))
 * Improve error message when OneAgentAPM is missing ([#327](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/327))
 * Improve descriptions on cr.yaml example ([#328](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/328))
 

--- a/deploy/common/deployment-operator.yaml
+++ b/deploy/common/deployment-operator.yaml
@@ -36,8 +36,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: ONEAGENT_OPERATOR_DEBUG_UNPRIVILEGED
-              value: "true"
           ports:
             - containerPort: 8080
               name: metrics

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -120,3 +120,8 @@ spec:
   # Optional: sets a NetworkZone for the OneAgent.
   #
   # networkZone: name-of-my-network-zone
+
+  # [On development, to be released as Early Preview]
+  # Optional: when enabled the OneAgent Pods will run as unprivileged. Disabled by default.
+  #
+  # useUnprivilegedMode: true

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -121,7 +121,7 @@ spec:
   #
   # networkZone: name-of-my-network-zone
 
-  # [On development, to be released as Early Preview]
+  # [On development, to be released as Early Adopter]
   # Optional: when enabled the OneAgent Pods will run as unprivileged. Disabled by default.
   #
   # useUnprivilegedMode: true

--- a/deploy/crds/dynatrace.com_oneagents_crd.yaml
+++ b/deploy/crds/dynatrace.com_oneagents_crd.yaml
@@ -287,7 +287,7 @@ spec:
               type: boolean
             useUnprivilegedMode:
               description: 'Optional: Runs the OneAgent Pods as unprivileged (Early
-                Preview)'
+                Adopter)'
               type: boolean
             waitReadySeconds:
               description: 'Optional: Defines the time to wait until OneAgent pod

--- a/deploy/crds/dynatrace.com_oneagents_crd.yaml
+++ b/deploy/crds/dynatrace.com_oneagents_crd.yaml
@@ -285,6 +285,10 @@ spec:
             useImmutableImage:
               description: Defines if you want to use the immutable image or the installer
               type: boolean
+            useUnprivilegedMode:
+              description: 'Optional: Runs the OneAgent Pods as unprivileged (Early
+                Preview)'
+              type: boolean
             waitReadySeconds:
               description: 'Optional: Defines the time to wait until OneAgent pod
                 is ready after update - default 300 sec'

--- a/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
+++ b/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
@@ -109,6 +109,12 @@ type OneAgentSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Labels"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:com.tectonic.ui:text"
 	Labels map[string]string `json:"labels,omitempty"`
+
+	// Optional: Runs the OneAgent Pods as unprivileged (Early Preview)
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Use unprivileged mode"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	UseUnprivilegedMode *bool `json:"useUnprivilegedMode,omitempty"`
 }
 
 type OneAgentPhaseType string

--- a/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
+++ b/pkg/apis/dynatrace/v1alpha1/oneagent_types.go
@@ -110,7 +110,7 @@ type OneAgentSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:com.tectonic.ui:text"
 	Labels map[string]string `json:"labels,omitempty"`
 
-	// Optional: Runs the OneAgent Pods as unprivileged (Early Preview)
+	// Optional: Runs the OneAgent Pods as unprivileged (Early Adopter)
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Use unprivileged mode"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:advanced,urn:alm:descriptor:com.tectonic.ui:booleanSwitch"

--- a/pkg/apis/dynatrace/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/dynatrace/v1alpha1/zz_generated.deepcopy.go
@@ -312,6 +312,11 @@ func (in *OneAgentSpec) DeepCopyInto(out *OneAgentSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.UseUnprivilegedMode != nil {
+		in, out := &in.UseUnprivilegedMode, &out.UseUnprivilegedMode
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/oneagent/oneagent_controller.go
+++ b/pkg/controller/oneagent/oneagent_controller.go
@@ -356,7 +356,10 @@ func (r *ReconcileOneAgent) updateCR(instance *dynatracev1alpha1.OneAgent) error
 }
 
 func newDaemonSetForCR(logger logr.Logger, instance *dynatracev1alpha1.OneAgent, clusterID string) (*appsv1.DaemonSet, error) {
-	unprivileged := os.Getenv("ONEAGENT_OPERATOR_DEBUG_UNPRIVILEGED") == "true"
+	unprivileged := false
+	if ptr := instance.GetOneAgentSpec().UseUnprivilegedMode; ptr != nil {
+		unprivileged = *ptr
+	}
 
 	podSpec := newPodSpecForCR(instance, unprivileged, logger, clusterID)
 	selectorLabels := buildLabels(instance.GetName())


### PR DESCRIPTION
The feature was previously configured through an environment variable. It's now the `useUnprivilegedMode` field on the OneAgent Custom Resource.