### PR TITLE
Use ConfigMap for leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Future
 
+#### Other changes
+* Upgrade to Operator SDK 1.3 ([#351](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/351))
+  * Use ConfigMaps for leases ([#367](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/341))
+
 ## v0.9
 
 ### v0.9.4

--- a/operator.go
+++ b/operator.go
@@ -31,14 +31,15 @@ import (
 func startOperator(ns string, cfg *rest.Config) (manager.Manager, error) {
 	log.Info(ns)
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Namespace:               ns,
-		Scheme:                  scheme,
-		MetricsBindAddress:      ":8080",
-		Port:                    8383,
-		LeaderElection:          true,
-		LeaderElectionID:        "dynatrace-oneagent-operator-lock",
-		LeaderElectionNamespace: ns,
-		HealthProbeBindAddress:  "0.0.0.0:10080",
+		Namespace:                  ns,
+		Scheme:                     scheme,
+		MetricsBindAddress:         ":8080",
+		Port:                       8383,
+		LeaderElection:             true,
+		LeaderElectionID:           "dynatrace-oneagent-operator-lock",
+		LeaderElectionResourceLock: "configmaps",
+		LeaderElectionNamespace:    ns,
+		HealthProbeBindAddress:     "0.0.0.0:10080",
 	})
 	if err != nil {
 		return nil, err

--- a/webhook_bootstrapper.go
+++ b/webhook_bootstrapper.go
@@ -27,13 +27,14 @@ import (
 
 func startWebhookBoostrapper(ns string, cfg *rest.Config) (manager.Manager, error) {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Namespace:               ns,
-		Scheme:                  scheme,
-		MetricsBindAddress:      ":8484",
-		LeaderElection:          true,
-		LeaderElectionID:        "dynatrace-oneagent-webhook-bootstrapper-lock",
-		LeaderElectionNamespace: ns,
-		HealthProbeBindAddress:  "0.0.0.0:9080",
+		Namespace:                  ns,
+		Scheme:                     scheme,
+		MetricsBindAddress:         ":8484",
+		LeaderElection:             true,
+		LeaderElectionID:           "dynatrace-oneagent-webhook-bootstrapper-lock",
+		LeaderElectionNamespace:    ns,
+		LeaderElectionResourceLock: "configmaps",
+		HealthProbeBindAddress:     "0.0.0.0:9080",
 	})
 	if err != nil {
 		return nil, err

--- a/webhook_server.go
+++ b/webhook_server.go
@@ -29,13 +29,14 @@ import (
 
 func startWebhookServer(ns string, cfg *rest.Config) (manager.Manager, error) {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Namespace:               ns,
-		Scheme:                  scheme,
-		MetricsBindAddress:      ":8383",
-		Port:                    8443,
-		LeaderElection:          true,
-		LeaderElectionID:        "dynatrace-oneagent-webhook-server-lock",
-		LeaderElectionNamespace: ns,
+		Namespace:                  ns,
+		Scheme:                     scheme,
+		MetricsBindAddress:         ":8383",
+		Port:                       8443,
+		LeaderElection:             true,
+		LeaderElectionID:           "dynatrace-oneagent-webhook-server-lock",
+		LeaderElectionResourceLock: "configmaps",
+		LeaderElectionNamespace:    ns,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
After migrating to the Operator SDK 1.3, and the controller-runtime 0.7, the default used for leases changed to "Lease" objects, instead of the previously used ConfigMaps.

These new objects aren't available on OCP 3.11, so going back to ConfigMaps.