### PR TITLE
Fix invalid argument APP_LOG_CONTENT_ACCESS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ spec:
   # certified image from Red Hat Container Catalog for use on OpenShift: registry.connect.redhat.com/dynatrace/oneagent
   # for kubernetes it defaults to docker.io/dynatrace/oneagent
   image: ""
-  # arguments to oneagent installer (optional)
-  # https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
+  # Optional: arguments to add to the OneAgent installer.
+  # Available options: https://www.dynatrace.com/support/help/shortlink/linux-custom-installation
+  # Limitations: https://www.dynatrace.com/support/help/shortlink/oneagent-docker#limitations
   args:
-  - APP_LOG_CONTENT_ACCESS=1
+    - "--set-app-log-content-access=true"
   # environment variables for oneagent (optional)
   env: []
   # resource settings for oneagent pods (optional)


### PR DESCRIPTION
This PR fixes the outdated `APP_LOG_CONTENT_ACCESS` oneagent arg that was still used in README.
It has already been fixed in the respective `cr.yaml`.

https://github.com/Dynatrace/dynatrace-oneagent-operator/blob/dd1977390a7cede557490027702aeb2940f918c6/deploy/cr.yaml#L38-L42
