### PR TITLE
Use the tag as version on master snapshot builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 #### Other changes
 * Upgrade to Operator SDK 1.3 ([#351](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/351))
-  * Use ConfigMaps for leases ([#367](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/341))
+  * Use ConfigMaps for leases ([#367](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/367))
+* Fix version and deployment instructions for dev builds ([#379](https://github.com/Dynatrace/dynatrace-oneagent-operator/pull/379))
 
 ## v0.9
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -13,13 +13,13 @@ There are automatic builds from the master branch. The latest development build 
 #### Kubernetes
 ```sh
 $ kubectl create namespace dynatrace
-$ kubectl apply -k github.com/Dynatrace/dynatrace-oneagent-operator/deploy/kubernetes
+$ kubectl apply -k github.com/Dynatrace/dynatrace-oneagent-operator/config/kubernetes
 ```
 
 #### OpenShift
 ```sh
 $ oc adm new-project --node-selector="" dynatrace
-$ oc apply -k github.com/Dynatrace/dynatrace-oneagent-operator/deploy/openshift
+$ oc apply -k github.com/Dynatrace/dynatrace-oneagent-operator/config/openshift
 ```
 
 #### Tests

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -2,13 +2,7 @@
 
 set -eu
 
-if [[ -z "$TRAVIS_TAG" ]]; then
-  version="snapshot-$(echo "$TRAVIS_BRANCH" | sed 's#[^a-zA-Z0-9_-]#-#g')"
-else
-  version="${TRAVIS_TAG}"
-fi
-
-go build -ldflags="-X 'github.com/Dynatrace/dynatrace-oneagent-operator/version.Version=${version}'" -tags containers_image_storage_stub -o ./build/_output/bin/dynatrace-oneagent-operator ./
+go build -ldflags="-X 'github.com/Dynatrace/dynatrace-oneagent-operator/version.Version=${TAG}'" -tags containers_image_storage_stub -o ./build/_output/bin/dynatrace-oneagent-operator ./
 
 if [[ "${GCR:-}" == "true" ]]; then
   echo "$GCLOUD_SERVICE_KEY" | base64 -d | docker login -u _json_key --password-stdin https://gcr.io


### PR DESCRIPTION
Previously master snapshot builds had "snapshot-master". With this PR, we use the tag instead, so just "snapshot" for this case.

Also fixed deployment instructions for dev builds.