### PR TITLE
changed apiVersion of SCC

### DIFF
--- a/config/openshift/securitycontextconstraints-unprivileged.yaml
+++ b/config/openshift/securitycontextconstraints-unprivileged.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   annotations:

--- a/config/openshift/securitycontextconstraints.yaml
+++ b/config/openshift/securitycontextconstraints.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   annotations:


### PR DESCRIPTION
when apiVersion was set to "v1" the SecurityContextConstraints were not applied due to the kind not being matched.