### PR TITLE
Explicitly sets environment variable value as string

### DIFF
--- a/config/openshift-common/deployment-operator-patch.yaml
+++ b/config/openshift-common/deployment-operator-patch.yaml
@@ -2,4 +2,4 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: DEPLOYED_ON_OPENSHIFT
-    value: true
+    value: "true"

--- a/config/openshift-common/deployment-webhook-patch.yaml
+++ b/config/openshift-common/deployment-webhook-patch.yaml
@@ -2,9 +2,9 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: DEPLOYED_ON_OPENSHIFT
-    value: true
+    value: "true"
 - op: add
   path: /spec/template/spec/containers/1/env/-
   value:
     name: DEPLOYED_ON_OPENSHIFT
-    value: true
+    value: "true"


### PR DESCRIPTION
The environment variable's value is interpreted as a boolean value in OCP 3.11, which leads to an error when trying to apply the manifest since it expects a string or null. This change explicitly marks the values as strings.