### PR TITLE
Update link to operator migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Dynatrace OneAgent Operator
 
->## **NOTE: The Dynatrace OneAgent Operator is deprecated and will not be supported anymore with Summer 2022. Please refer to [Migrating from OneAgent Operator to Dynatrace Operator](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/migrate-to-dynatrace-operator-k8/).**
+>## **NOTE: The Dynatrace OneAgent Operator is deprecated and will not be supported anymore with Summer 2022. Please refer to [Migrating from OneAgent Operator to Dynatrace Operator](https://dt-url.net/oneagent-operator-migration).**
 <br>
 
 This is the home of Dynatrace OneAgent Operator which supports the rollout and lifecycle of [Dynatrace OneAgent](https://www.dynatrace.com/support/help/get-started/introduction/what-is-oneagent/) in Kubernetes and OpenShift clusters.


### PR DESCRIPTION
Official documentation structure was changed so the links need to be updated to reflect these changes.